### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/src/elan-cli/main.rs
+++ b/src/elan-cli/main.rs
@@ -28,7 +28,7 @@ extern crate time;
 extern crate rand;
 extern crate same_file;
 extern crate scopeguard;
-extern crate tempdir;
+extern crate tempfile;
 extern crate sha2;
 extern crate markdown;
 extern crate toml;

--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -43,7 +43,7 @@ use std::path::{Path, PathBuf, Component};
 use std::process::{self, Command};
 use std::fs;
 use tar;
-use tempdir::TempDir;
+use tempfile::tempdir;
 use term2;
 use regex::Regex;
 use zip;
@@ -1225,7 +1225,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     let update_root = env::var("ELAN_UPDATE_ROOT")
         .unwrap_or(String::from(UPDATE_ROOT));
 
-    let tempdir = try!(TempDir::new("elan-update")
+    let tempdir = try!(tempdir()
         .chain_err(|| "error creating temp directory"));
 
     // Get current version


### PR DESCRIPTION
The tempdir crate has been [deprecated](https://crates.io/crates/tempdir) in favour of tempfile.

This PR switches elan to use tempfile instead of tempdir.