### PR TITLE
fix: redundant prompt on windows in v1.1.1

### DIFF
--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -269,15 +269,6 @@ pub fn install(no_prompt: bool, verbose: bool,
             }
         };
         term2::stdout().md(msg);
-
-        // On windows, where installation happens in a console
-        // that may have opened just for this purpose, require
-        // the user to press a key to continue.
-        if cfg!(windows) {
-            println!("");
-            println!("Press the Enter key to continue.");
-            try!(common::read_line());
-        }
     }
 
     Ok(())


### PR DESCRIPTION
fix: while testing v1.1.1 I found another redundant prompt on windows

![image](https://user-images.githubusercontent.com/18707114/137442503-46eafcf9-84e5-44bc-a491-b520f10a33c1.png)
