### PR TITLE
fix win error code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,9 @@ jobs:
           RUST_BACKTRACE=1 target/${{ matrix.target }}/release/elan-init -y
           # not created on Windows
           [ -f ~/.elan/env ] && source ~/.elan/env || export PATH=$PATH:~/.elan/bin
-          elan which lake
-          lake new foo
-          (cd foo; lake build)
+          elan which leanpkg
+          leanpkg new foo
+          (cd foo; leanpkg build)
           elan default leanprover/lean4:nightly
           mkdir foo4; cd foo4
           lake init foo4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,13 @@ jobs:
           RUST_BACKTRACE=1 target/${{ matrix.target }}/release/elan-init -y
           # not created on Windows
           [ -f ~/.elan/env ] && source ~/.elan/env || export PATH=$PATH:~/.elan/bin
-          elan which leanpkg
-          leanpkg new foo
-          (cd foo; leanpkg build)
+          elan which lake
+          lake new foo
+          (cd foo; lake build)
           elan default leanprover/lean4:nightly
           mkdir foo4; cd foo4
-          leanpkg init foo4
-          leanpkg build
+          lake init foo4
+          lake build
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')
         with:

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -17,35 +17,13 @@
     Whee to find the elan-init tool, default is https://github.com/leanprover/elan/release.
 #>
 param(
-    [bool]$Verbose = $false,
-    [bool]$NoMenu = $false,
-    [bool]$PromptOnError = $false,
+    [bool]$Verbose = 0,
+    [bool]$NoMenu = 0,
+    [bool]$PromptOnError = 0,
     [string]$DefaultToolchain = "none",
     [string]$ElanRoot = "https://github.com/leanprover/elan/releases"
 )
 
-
-#XXX: If you change anything here, please make the same changes in setup_mode.rs
-function usage() {
-    Write-Host "
-elan-init 1.0.0 (408ed84 2017-02-11)
-The installer for elan
-
-USAGE:
-    elan-init [FLAGS] [OPTIONS]
-
-FLAGS:
-    -v, --verbose           Enable verbose output
-    -y                      Disable confirmation prompt.
-        --no-modify-path    Don't configure the PATH environment variable
-    -h, --help              Prints help information
-    -V, --version           Prints version information
-
-OPTIONS:
-        --default-toolchain <default-toolchain>    Choose a default toolchain to install
-        --default-toolchain none                   Do not install any toolchains
-"
-}
 
 Function Get-RedirectedUrl {
     Param (

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -3,7 +3,6 @@
 # install elan. It just does platform detection, downloads the installer
 # and runs it.
 
-
 $ELAN_UPDATE_ROOT="https://github.com/leanprover/elan/releases"
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
@@ -77,20 +76,21 @@ function main($cmdline) {
     Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
 
     if ($cmdline.Count -eq 0) {
-        Start-Process -FilePath "$_dir/elan-init.exe" -Wait -NoNewWindow
+        $details = Start-Process -FilePath "$_dir/elan-init.exe" -Wait -NoNewWindow -Passthru
     } else {
-        Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow
+        $details = Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
     }
 
-    if( -not $? ) {
-        Write-Host "Elan failed with error code $?"
+    $rc = $details.exitCode
+    if ($rc -ne 0 ) {
+        Write-Host "Elan failed with error code $rc "
         return 1
     }
 
     Remove-Item -Recurse -Force "$_dir"
 
-    return 0
+    return $rc
 }
 
 $rc = main -cmdline $args
-Exit $rc
+return $rc

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -1,9 +1,29 @@
+<#
+.SYNOPSIS
+    .
+.DESCRIPTION
+    This is just a little script that can be downloaded from the internet to
+    install elan. It just does platform detection, downloads the installer
+    and runs it.
+.PARAMETER Verbose
+    Produce verbose output about the elan installation process.
+.PARAMETER NoMenu
+    Do not present elan installation menu of choices.
+.PARAMETER PromptOnError
+    Prompt user if install fails.
+.PARAMETER DefaultToolchain
+    Which tool chain to setup as your default toolchain, default is 'none'
+.PARAMETER ElanRoot
+    Whee to find the elan-init tool, default is https://github.com/leanprover/elan/release.
+#>
+param(
+    [bool]$Verbose = $false,
+    [bool]$NoMenu = $false,
+    [bool]$PromptOnError = $false,
+    [string]$DefaultToolchain = "none",
+    [string]$ElanRoot = "https://github.com/leanprover/elan/releases"
+)
 
-# This is just a little script that can be downloaded from the internet to
-# install elan. It just does platform detection, downloads the installer
-# and runs it.
-
-$ELAN_UPDATE_ROOT="https://github.com/leanprover/elan/releases"
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
 function usage() {
@@ -49,48 +69,47 @@ Function Get-RedirectedUrl {
     }
 }
 
-function main($cmdline) {
+$cputype=[System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
 
-    $cputype=[System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-
-    if ($cputype -ne "AMD64") {
-        Write-Host "### Elan install only supports 64 bit windows with AMD64 architecture"
-        return 1
-    }
-
-    $_arch="x86_64-pc-windows-msvc"
-    $_ext = ".exe"
-    $temp = [System.IO.Path]::GetTempPath()
-    $_dir = Join-Path $temp "elan"
-    if (-not (Test-Path -Path $_dir)) {
-        New-Item -ItemType Directory -Path $_dir
-    }
-    $_file = "$_dir/elan-init$_ext"
-
-    Write-Host "info: downloading installer to ${temp}"
-
-    $x = Get-RedirectedUrl "https://github.com/leanprover/elan/releases/latest"
-    $xs =  -split $x -split '/'
-    $_latest = $xs[-1]
-    Invoke-WebRequest -Uri "$ELAN_UPDATE_ROOT/download/$_latest/elan-$_arch.zip" -OutFile "$_dir/elan-init.zip"
-    Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
-
-    if ($cmdline.Count -eq 0) {
-        $details = Start-Process -FilePath "$_dir/elan-init.exe" -Wait -NoNewWindow -Passthru
-    } else {
-        $details = Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
-    }
-
-    $rc = $details.exitCode
-    if ($rc -ne 0 ) {
-        Write-Host "Elan failed with error code $rc "
-        return 1
-    }
-
-    Remove-Item -Recurse -Force "$_dir"
-
-    return $rc
+if ($cputype -ne "AMD64") {
+    Write-Host "### Elan install only supports 64 bit windows with AMD64 architecture"
+    return 1
 }
 
-$rc = main -cmdline $args
-return $rc
+$_arch="x86_64-pc-windows-msvc"
+$_ext = ".exe"
+$temp = [System.IO.Path]::GetTempPath()
+$_dir = Join-Path $temp "elan"
+if (-not (Test-Path -Path $_dir)) {
+    $x = New-Item -ItemType Directory -Path $_dir
+}
+$_file = "$_dir/elan-init$_ext"
+
+Write-Host "info: downloading installer to ${temp}"
+
+$x = Get-RedirectedUrl "https://github.com/leanprover/elan/releases/latest"
+$xs =  -split $x -split '/'
+$_latest = $xs[-1]
+$x = Invoke-WebRequest -Uri "$ElanRoot/download/$_latest/elan-$_arch.zip" -OutFile "$_dir/elan-init.zip"
+$x = Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
+
+$cmdline = "--default-toolchain $DefaultToolchain"
+if ($NoMenu){
+    $cmdline = $cmdline + " -y"
+}
+$details = Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
+
+$rc = $details.exitCode
+if ($rc -ne 0 ) {
+    Write-Host "Elan failed with error code $rc"
+    if ($PromptOnError){
+        Write-Host
+        Read-Host -Prompt "Press ENTER key to continue "
+    }
+    return 1
+}
+
+$rx = Remove-Item -Recurse -Force "$_dir"
+
+
+return 0


### PR DESCRIPTION
The error code was getting lost in the powershell script `elan-init-ps1`, so I fixed it and while I was at it I added a new -PromptOnError option so I don't have to do any tricky logic in the leanInstaller typescript in the vscode extension.

Related to https://github.com/leanprover/vscode-lean4/pull/157