### PR TITLE
fix: make command line consistent (part 1)

### DIFF
--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -9,6 +9,10 @@
     Produce verbose output about the elan installation process.
 .PARAMETER NoMenu
     Do not present elan installation menu of choices.
+.PARAMETER NoPrompt
+    Do not present elan installation menu of choices.
+.PARAMETER NoModifyPath
+    Do not modify PATH environment variable.
 .PARAMETER PromptOnError
     Prompt user if install fails.
 .PARAMETER DefaultToolchain
@@ -19,8 +23,10 @@
 param(
     [bool]$Verbose = 0,
     [bool]$NoMenu = 0,
+    [bool]$NoPrompt = 0,
+    [bool]$NoModifyPath = 0,
     [bool]$PromptOnError = 0,
-    [string]$DefaultToolchain = "none",
+    [string]$DefaultToolchain = "",
     [string]$ElanRoot = "https://github.com/leanprover/elan/releases"
 )
 
@@ -71,9 +77,18 @@ $_latest = $xs[-1]
 $x = Invoke-WebRequest -Uri "$ElanRoot/download/$_latest/elan-$_arch.zip" -OutFile "$_dir/elan-init.zip"
 $x = Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
 
-$cmdline = "--default-toolchain $DefaultToolchain"
-if ($NoMenu){
-    $cmdline = $cmdline + " -y"
+$cmdline = ""
+if ($DefaultToolchain) {
+    $cmdline += "--default-toolchain $DefaultToolchain"
+}
+if ($NoMenu -or $NoPrompt){
+    $cmdline += " -y"
+}
+if ($NoModifyPath){
+    $cmdline += " --no-modify-path"
+}
+if ($Verbose){
+    $cmdline += " --verbose"
 }
 $details = Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
 


### PR DESCRIPTION
**Note:** in order to ensure I do not break the vscode-lean4 extension I will do this in 2 stages.  First is to add only new options then I can move vscode extension over to those then later to remove the old options (-NoMenu and -PromptOnError).

Chris Lovett: From your discussion in https://github.com/leanprover/vscode-lean4/pull/151 let me summarize:

- add powershell -NoModifyPath to map to the no-modify-path elan-init option (hmmm, the vscode extension probably should be using this option).
- remove -PromptOnError since elan-init doesn't have that option (and do this part in vscode extension).
- change -NoPrompt to -NoMenu to match the -no-prompt option in elan-init.

Sebastian Ullrich: Okay, that sounds acceptable. Whether the extension should modify the path is a good question. I think people will expect leanto work from their cmdline as well after installation.

