### PR TITLE
Fix for Windows Server 2016 download using VSCode extension

### DIFF
--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -39,7 +39,7 @@ $_ext = ".exe"
 $temp = [System.IO.Path]::GetTempPath()
 $_dir = Join-Path $temp "elan"
 if (-not (Test-Path -Path $_dir)) {
-    $x = New-Item -ItemType Directory -Path $_dir
+    $null = New-Item -ItemType Directory -Path $_dir
 }
 $_file = "$_dir/elan-init$_ext"
 
@@ -60,7 +60,7 @@ catch {
     return 1
 }
 
-$x = Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
+$null = Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
 
 $cmdline = " "
 if ($DefaultToolchain -ne "") {
@@ -83,6 +83,6 @@ if ($rc -ne 0 ) {
     return 1
 }
 
-$rx = Remove-Item -Recurse -Force "$_dir"
+$null = Remove-Item -Recurse -Force "$_dir"
 
 return 0

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -1,40 +1,47 @@
 <#
 .SYNOPSIS
     .
+
 .DESCRIPTION
     This is just a little script that can be downloaded from the Internet to
     install elan. It just does platform detection, downloads the latest
     installer, then runs it.
+
 .PARAMETER Verbose
     Produce verbose output about the elan installation process.
+
 .PARAMETER NoPrompt
     Do not present elan installation menu of choices.
+
 .PARAMETER NoModifyPath
     Do not modify PATH environment variable.
+
 .PARAMETER DefaultToolchain
     Which tool chain to setup as your default toolchain, or specify 'none'
+
 .PARAMETER ElanRoot
     Where to find the elan-init tool, default is https://github.com/leanprover/elan/releases
+
 .PARAMETER ElanVersion
     Specific version of elan to download and run instead of latest, e.g. 1.4.1
 #>
 param(
-    [bool]$Verbose = 0,
-    [bool]$NoPrompt = 0,
-    [bool]$NoModifyPath = 0,
-    [string]$DefaultToolchain = "",
-    [string]$ElanRoot = "https://github.com/leanprover/elan/releases",
-    [string]$ElanVersion = ""
+    [bool] $Verbose = 0,
+    [bool] $NoPrompt = 0,
+    [bool] $NoModifyPath = 0,
+    [string] $DefaultToolchain = "",
+    [string] $ElanRoot = "https://github.com/leanprover/elan/releases",
+    [string] $ElanVersion = ""
 )
 
-$cputype=[System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+$cputype = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
 
 if ($cputype -ne "AMD64") {
     Write-Host "### Elan install only supports 64-bit Windows with AMD64 architecture"
     return 1
 }
 
-$_arch="x86_64-pc-windows-msvc"
+$_arch = "x86_64-pc-windows-msvc"
 $_ext = ".exe"
 $temp = [System.IO.Path]::GetTempPath()
 $_dir = Join-Path $temp "elan"
@@ -66,13 +73,13 @@ $cmdline = " "
 if ($DefaultToolchain -ne "") {
     $cmdline += "--default-toolchain $DefaultToolchain"
 }
-if ($NoPrompt){
+if ($NoPrompt) {
     $cmdline += " -y"
 }
-if ($NoModifyPath){
+if ($NoModifyPath) {
     $cmdline += " --no-modify-path"
 }
-if ($Verbose){
+if ($Verbose) {
     $cmdline += " --verbose"
 }
 $details = Start-Process -FilePath "$_file" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -75,7 +75,7 @@ if ($NoModifyPath){
 if ($Verbose){
     $cmdline += " --verbose"
 }
-$details = Start-Process -FilePath "$_dir/elan-init.exe" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
+$details = Start-Process -FilePath "$_file" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
 
 $rc = $details.exitCode
 if ($rc -ne 0 ) {

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -2,9 +2,9 @@
 .SYNOPSIS
     .
 .DESCRIPTION
-    This is just a little script that can be downloaded from the internet to
-    install elan. It just does platform detection, downloads the installer
-    and runs it.
+    This is just a little script that can be downloaded from the Internet to
+    install elan. It just does platform detection, downloads the latest
+    installer, then runs it.
 .PARAMETER Verbose
     Produce verbose output about the elan installation process.
 .PARAMETER NoPrompt
@@ -14,7 +14,7 @@
 .PARAMETER DefaultToolchain
     Which tool chain to setup as your default toolchain, or specify 'none'
 .PARAMETER ElanRoot
-    Whee to find the elan-init tool, default is https://github.com/leanprover/elan/release.
+    Where to find the elan-init tool, default is https://github.com/leanprover/elan/releases
 .PARAMETER ElanVersion
     Specific version of elan to download and run instead of latest, e.g. 1.4.1
 #>
@@ -30,7 +30,7 @@ param(
 $cputype=[System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
 
 if ($cputype -ne "AMD64") {
-    Write-Host "### Elan install only supports 64 bit windows with AMD64 architecture"
+    Write-Host "### Elan install only supports 64-bit Windows with AMD64 architecture"
     return 1
 }
 


### PR DESCRIPTION
When called by the VSCode extension, Windows Server 2016 defaults to SSL3.0/TLS1.0 and will not download files using `Invoke-WebRequest`. BITS does not have this issue. Have fixed the issue in https://github.com/leanprover/vscode-lean4/pull/246, but didn't realise it was here, too.

Switched the download for the zip from `Invoke-WebRequest` to `Start-BitsTransfer`.

Also, [linked directly to the latest release](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases) (so `Get-RedirectUrl` is no longer required), and added the `ElanVersion` parameter in case somebody wants to download a specific version of elan. It continues to default to downloading "latest".

Have tested on Windows 10, Server 2016, and Server 2019.