### PR TITLE
fix: when toolchains are empty, message is confusing

### DIFF
--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -204,6 +204,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
+        info!("toolchains can be empty, try: elan toolchain install leanprover/lean4:nightly")
     }
 
     let setup_path = if self_update {

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -204,7 +204,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed.");
-        info!("use elan toolchain install to install a toolchain.")
+        info!("use 'elan toolchain install' to install a toolchain.")
     }
 
     let setup_path = if self_update {

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -204,7 +204,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
-        info!("no toolchains are installed, please try elan toolchain install instead.")
+        info!("no toolchains are installed, use elan toolchain install instead.")
     }
 
     let setup_path = if self_update {

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -203,8 +203,8 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
     let toolchains = cfg.update_all_channels(force_update)?;
 
     if toolchains.is_empty() {
-        info!("no updatable toolchains installed");
-        info!("no toolchains are installed, use elan toolchain install instead.")
+        info!("no updatable toolchains installed.");
+        info!("use elan toolchain install to install a toolchain.")
     }
 
     let setup_path = if self_update {

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -204,7 +204,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
-        info!("toolchains can be empty, try: elan toolchain install leanprover/lean4:nightly")
+        info!("toolchains can be empty, try elan toolchain install instead.")
     }
 
     let setup_path = if self_update {

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -204,7 +204,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> 
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
-        info!("toolchains can be empty, try elan toolchain install instead.")
+        info!("no toolchains are installed, please try elan toolchain install instead.")
     }
 
     let setup_path = if self_update {


### PR DESCRIPTION
This fix adds a second message, in case we want to install the default version of lean.