### PR TITLE
fix display glitch of download progress

### DIFF
--- a/src/elan-cli/download_tracker.rs
+++ b/src/elan-cli/download_tracker.rs
@@ -141,7 +141,7 @@ impl DownloadTracker {
                 let eta_h = HumanReadable(remaining / speed);
                 let _ = write!(
                     self.term.as_mut().unwrap(),
-                    "{} / {} ({:3.0} %) {}/s ETA: {:#}",
+                    "\x0d{} / {} ({:3.0} %) {}/s ETA: {:#}",
                     total_h,
                     content_len_h,
                     percent,

--- a/src/elan-cli/download_tracker.rs
+++ b/src/elan-cli/download_tracker.rs
@@ -32,7 +32,10 @@ pub struct DownloadTracker {
     /// If the download is quick enough, we don't have time to
     /// display the progress info.
     /// In that case, we do not want to do some cleanup stuff we normally do.
-    displayed_progress: bool,
+    ///
+    /// If we have displayed progress, this is the number of characters we
+    /// rendered, so we can erase it cleanly.
+    displayed_charcount: Option<usize>,
 }
 
 impl DownloadTracker {
@@ -46,7 +49,7 @@ impl DownloadTracker {
             seconds_elapsed: 0,
             last_sec: None,
             term: term::stdout(),
-            displayed_progress: false,
+            displayed_charcount: None,
         }
     }
 
@@ -104,7 +107,7 @@ impl DownloadTracker {
     }
     /// Notifies self that the download has finished.
     pub fn download_finished(&mut self) {
-        if self.displayed_progress {
+        if self.displayed_charcount.is_some() {
             // Display the finished state
             self.display();
             let _ = writeln!(self.term.as_mut().unwrap(), "");
@@ -119,7 +122,7 @@ impl DownloadTracker {
         self.downloaded_last_few_secs.clear();
         self.seconds_elapsed = 0;
         self.last_sec = None;
-        self.displayed_progress = false;
+        self.displayed_charcount = None;
     }
     /// Display the tracked download information to the terminal.
     fn display(&mut self) {
@@ -132,38 +135,50 @@ impl DownloadTracker {
         let speed = if len > 0 { sum / len as f64 } else { 0. };
         let speed_h = HumanReadable(speed);
 
-        match self.content_len {
+        // First, move to the start of the current line and clear it.
+        let _ = write!(self.term.as_mut().unwrap(), "\r");
+        // We'd prefer to use delete_line() but on Windows it seems to
+        // sometimes do unusual things
+        // let _ = self.term.as_mut().unwrap().delete_line();
+        // So instead we do:
+        if let Some(n) = self.displayed_charcount {
+            // This is not ideal as very narrow terminals might mess up,
+            // but it is more likely to succeed until term's windows console
+            // fixes whatever's up with delete_line().
+            let _ = write!(self.term.as_mut().unwrap(), "{}", " ".repeat(n));
+            let _ = self.term.as_mut().unwrap().flush();
+            let _ = write!(self.term.as_mut().unwrap(), "\r");
+        }
+
+        let output: String = match self.content_len {
             Some(content_len) => {
                 let content_len = content_len as f64;
                 let percent = (self.total_downloaded as f64 / content_len) * 100.;
                 let content_len_h = HumanReadable(content_len);
                 let remaining = content_len - self.total_downloaded as f64;
                 let eta_h = HumanReadable(remaining / speed);
-                let _ = write!(
-                    self.term.as_mut().unwrap(),
-                    "\x0d{} / {} ({:3.0} %) {}/s ETA: {:#}",
+                format!(
+                    "{} / {} ({:3.0} %) {}/s ETA: {:#}",
                     total_h,
                     content_len_h,
                     percent,
                     speed_h,
                     eta_h
-                );
+                )
             }
             None => {
-                let _ = write!(
-                    self.term.as_mut().unwrap(),
+                format!(
                     "Total: {} Speed: {}/s",
                     total_h,
                     speed_h
-                );
+                )
             }
-        }
-        // delete_line() doesn't seem to clear the line properly.
-        // Instead, let's just print some whitespace to clear it.
-        let _ = write!(self.term.as_mut().unwrap(), "                ");
+        };
+
+        let _ = write!(self.term.as_mut().unwrap(), "{output}");
+        // Since stdout is typically line-buffered and we don't print a newline, we manually flush.
         let _ = self.term.as_mut().unwrap().flush();
-        let _ = self.term.as_mut().unwrap().carriage_return();
-        self.displayed_progress = true;
+        self.displayed_charcount = Some(output.chars().count());
     }
 }
 


### PR DESCRIPTION
```pwsh
$ elan update stable
info: syncing channel updates for 'stable'
info: latest update on stable, lean version v4.0.0-m5
info: downloading component 'lean'
  6.9 MiB / 139.1 MiB (  5 %)   0 B/s ETA: Unknown                 19.1 MiB / 139.1 MiB ( 14 %)   6.9 MiB/s ETA:  17 s
               30.2 MiB / 139.1 MiB ( 22 %)   9.5 MiB/s ETA:  11 s                 41.4 MiB / 139.1 MiB ( 30 %)  10.1 MiB/s ETA:  10 s                 52.5 MiB / 139.1 MiB ( 38 %)  10.3 MiB/s ETA:   8 s                 63.6 MiB / 139.1 MiB ( 46 %)  10.5 MiB/s ETA:   7 s                 74.7 MiB / 139.1 MiB ( 54 %)  11.3 MiB/s ETA:   6 s                 86.0 MiB / 139.1 MiB ( 62 %)  11.1 MiB/s ETA:   5 s                 97.1 MiB / 139.1 MiB ( 70 %)  11.2 MiB/s ETA:   4 s
          108.3 MiB / 139.1 MiB ( 78 %)  11.2 MiB/s ETA:   3 s                119.4 MiB / 139.1 MiB ( 86 %)  11.2 MiB/s ETA:   2 s                130.6 MiB / 139.1 MiB ( 94 %)  11.2 MiB/s ETA:   1 s                139.1 MiB / 139.1 MiB (100 %)  11.2 MiB/s ETA:   0 s
info: installing component 'lean'

  stable installed - Lean (version 4.0.0, commit 7dbfaf9b7519, Release)

```
The download progress is bad displayed.
Add carriage return (\x0d) to fix it.
```pwsh
$ elan update stable
info: syncing channel updates for 'stable'
info: latest update on stable, lean version v4.0.0-m5
info: downloading component 'lean'
139.1 MiB / 139.1 MiB (100 %)  11.0 MiB/s ETA:   0 s
info: installing component 'lean'

  stable installed - Lean (version 4.0.0, commit 7dbfaf9b7519, Release)

```