### PR TITLE
Eagerly resolve toolchains to canonical, fixed reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         shell: bash
         run: |
           echo $HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
+          # still necessary??
+          echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
       - name: Build
         run: |
           cargo install cross --locked
@@ -74,8 +76,7 @@ jobs:
         shell: bash
         run: |
           cd target/${{ matrix.target  }}/release
-          which tar
-          tar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init || gtar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init
+          tar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init
         if: matrix.os != 'windows-latest'
       - name: Package
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: |
-          brew install coreutils
+          brew install gnu-tar
           echo $HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,12 @@ jobs:
             release-target-name: aarch64-unknown-linux-gnu
             binary-check: true
           - name: macOS
-            os: macos-latest
+            os: macos-13
             target: x86_64-apple-darwin
             binary-check: otool -L
           - name: macOS aarch64
-            os: macos-latest
+            os: macos-14
             target: aarch64-apple-darwin
-            skip-tests: true
             binary-check: otool -L
           - name: Windows
             os: windows-latest
@@ -61,11 +60,11 @@ jobs:
             target
           key: ${{ matrix.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup macOS
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: |
           brew install coreutils
-          echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
+          echo $HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
       - name: Build
         run: |
           cargo install cross --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: |
-          brew install gnu-tar
           echo $HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
       - name: Build
         run: |
@@ -75,7 +74,8 @@ jobs:
         shell: bash
         run: |
           cd target/${{ matrix.target  }}/release
-          tar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init
+          which tar
+          tar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init || gtar --portability -czf ../../../elan-${{ matrix.release-target-name || matrix.target }}.tar.gz elan-init
         if: matrix.os != 'windows-latest'
       - name: Package
         run: |

--- a/elan-init.sh
+++ b/elan-init.sh
@@ -34,8 +34,8 @@ FLAGS:
     -V, --version           Prints version information
 
 OPTIONS:
-        --default-toolchain <default-toolchain>    Choose a default toolchain to install
-        --default-toolchain none                   Do not install any toolchains
+        --default-toolchain <default-toolchain>    Choose a default toolchain
+        --default-toolchain none                   Do not set a default toolchain
 EOF
 }
 

--- a/fetch_nixos_patch.sh
+++ b/fetch_nixos_patch.sh
@@ -1,0 +1,1 @@
+nix build -o nixos.patch $(nix eval nixpkgs#elan.patches --apply "patches: (builtins.elemAt patches 0).outPath" --raw)

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -5,7 +5,6 @@ use elan_dist::dist::ToolchainDesc;
 use elan_utils::notify::NotificationLevel;
 use elan_utils::utils;
 use errors::*;
-use self_update;
 use std;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
@@ -196,38 +195,6 @@ fn show_channel_updates(
         let _ = writeln!(t, " - {}", version);
     }
     let _ = writeln!(t, "");
-
-    Ok(())
-}
-
-pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> Result<()> {
-    let toolchains = cfg.update_all_channels(force_update)?;
-
-    if toolchains.is_empty() {
-        info!("no updatable toolchains installed.");
-        info!("use 'elan toolchain install' to install a toolchain.")
-    }
-
-    let setup_path = if self_update {
-        self_update::prepare_update()?
-    } else {
-        None
-    };
-
-    if !toolchains.is_empty() {
-        println!("");
-
-        show_channel_updates(cfg, toolchains)?;
-    }
-
-    if let Some(ref setup_path) = setup_path {
-        self_update::run_update(setup_path)?;
-
-        unreachable!(); // update exits on success
-    } else if self_update {
-        // Try again in case we emitted "tool `{}` is already installed" last time.
-        self_update::install_proxies()?;
-    }
 
     Ok(())
 }

--- a/src/elan-cli/elan_mode.rs
+++ b/src/elan-cli/elan_mode.rs
@@ -231,8 +231,8 @@ pub fn cli() -> App<'static, 'static> {
 }
 
 fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
-    let ref toolchain = m.value_of("toolchain").expect("");
-    let toolchain = ToolchainDesc::from_str(toolchain)?;
+    let ref name = m.value_of("toolchain").expect("");
+    let toolchain = ToolchainDesc::from_str(name)?;
     let ref toolchain = cfg.get_toolchain(&toolchain, false)?;
 
     let status = if !toolchain.exists() || !toolchain.is_custom() {
@@ -241,7 +241,7 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
         None
     };
 
-    toolchain.make_default()?;
+    cfg.set_default(name)?;
 
     if let Some(status) = status {
         println!("");
@@ -319,13 +319,8 @@ fn show(cfg: &Cfg) -> Result<()> {
         if show_headers {
             print_header("installed toolchains")
         }
-        let default_name = cfg.get_default()?;
         for t in installed_toolchains {
-            if default_name.as_ref() == Some(&t) {
-                println!("{} (default)", t);
-            } else {
-                println!("{}", t);
-            }
+            println!("{}", t);
         }
         if show_headers {
             println!("")

--- a/src/elan-cli/elan_mode.rs
+++ b/src/elan-cli/elan_mode.rs
@@ -1,6 +1,7 @@
 use clap::{App, AppSettings, Arg, ArgMatches, Shell, SubCommand};
 use common;
 use elan::{command, lookup_toolchain_desc, Cfg, Toolchain};
+use elan_dist::dist::ToolchainDesc;
 use elan_utils::utils;
 use errors::*;
 use help::*;
@@ -388,7 +389,7 @@ fn explicit_or_dir_toolchain<'a>(cfg: &'a Cfg, m: &ArgMatches) -> Result<Toolcha
 fn toolchain_link(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let ref toolchain = m.value_of("toolchain").expect("");
     let ref path = m.value_of("path").expect("");
-    let desc = lookup_toolchain_desc(cfg, toolchain)?;
+    let desc = ToolchainDesc::from_resolved_str(toolchain)?;
     let toolchain = cfg.get_toolchain(&desc, true)?;
 
     Ok(toolchain.install_from_dir(Path::new(path), true)?)

--- a/src/elan-cli/help.rs
+++ b/src/elan-cli/help.rs
@@ -12,14 +12,6 @@ pub static SHOW_HELP: &'static str = r"DISCUSSION:
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.";
 
-pub static UPDATE_HELP: &'static str = r"DISCUSSION:
-    With no toolchain specified, the `update` command updates each of
-    the installed toolchains from the official release channels, then
-    updates elan itself.
-
-    If given a toolchain argument then `update` updates that
-    toolchain, the same as `elan toolchain install`.";
-
 pub static INSTALL_HELP: &'static str = r"DISCUSSION:
     Installs a specific lean toolchain.
 

--- a/src/elan-cli/help.rs
+++ b/src/elan-cli/help.rs
@@ -18,8 +18,7 @@ pub static INSTALL_HELP: &'static str = r"DISCUSSION:
     The 'install' command is an alias for 'elan update <toolchain>'.";
 
 pub static DEFAULT_HELP: &'static str = r"DISCUSSION:
-    Sets the default toolchain to the one specified. If the toolchain
-    is not already installed then it is installed first.";
+    Sets the default toolchain to the one specified.";
 
 pub static TOOLCHAIN_HELP: &'static str = r"DISCUSSION:
     Many `elan` commands deal with *toolchains*, a single

--- a/src/elan-cli/proxy_mode.rs
+++ b/src/elan-cli/proxy_mode.rs
@@ -1,8 +1,7 @@
 use common::set_globals;
 use elan::command::run_command_for_dir;
-use elan::Cfg;
+use elan::{lookup_toolchain_desc, Cfg};
 use elan_utils::utils;
-use elan_dist::dist::ToolchainDesc;
 use errors::*;
 use job;
 use std::env;
@@ -50,7 +49,7 @@ fn direct_proxy(cfg: &Cfg, arg0: &str, toolchain: Option<&str>, args: &[OsString
     let cmd = match toolchain {
         None => cfg.create_command_for_dir(&utils::current_dir()?, arg0)?,
         Some(tc) => {
-            let desc = ToolchainDesc::from_str(tc)?;
+            let desc = lookup_toolchain_desc(cfg, tc)?;
             cfg.create_command_for_toolchain(&desc, true, arg0)?
         }
     };

--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -232,7 +232,12 @@ pub fn install(no_prompt: bool, verbose: bool, mut opts: InstallOpts) -> Result<
         if !opts.no_modify_path {
             do_add_to_path(&get_add_path_methods())?;
         }
-        maybe_install_lean(&opts.default_toolchain, verbose)?;
+        if opts.default_toolchain != "none" {
+            // sanity-check reference
+            let _ = ToolchainDesc::from_str(&opts.default_toolchain)?;
+            let ref cfg = common::set_globals(verbose)?;
+            cfg.set_default(&opts.default_toolchain)?;
+        }
 
         if cfg!(unix) {
             let ref env_file = utils::elan_home()?.join("env");
@@ -528,31 +533,6 @@ pub fn install_proxies() -> Result<()> {
     drop(tool_handles);
     for path in link_afterwards {
         utils::hard_or_symlink_file(elan_path, &path)?;
-    }
-
-    Ok(())
-}
-
-fn maybe_install_lean(toolchain_str: &str, verbose: bool) -> Result<()> {
-    let ref cfg = common::set_globals(verbose)?;
-
-    // If there is already an install, then `toolchain_str` may not be
-    // a toolchain the user actually wants. Don't do anything.  FIXME:
-    // This logic should be part of InstallOpts so that it isn't
-    // possible to select a toolchain then have it not be installed.
-    if toolchain_str == "none" {
-        info!("skipping toolchain installation");
-        println!("");
-    } else if cfg.find_default()?.is_none() {
-        let desc = ToolchainDesc::from_str(toolchain_str)?;
-        let toolchain = cfg.get_toolchain(&desc, false)?;
-        let status = toolchain.install_from_dist()?;
-        cfg.set_default(&desc)?;
-        println!("");
-        common::show_channel_update(cfg, &desc, Ok(status))?;
-    } else {
-        info!("updating existing elan installation");
-        println!("");
     }
 
     Ok(())

--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -31,8 +31,8 @@
 //! and racy on Windows.
 
 use common::{self, Confirm};
+use elan::lookup_toolchain_desc;
 use elan_dist::dist;
-use elan_dist::dist::ToolchainDesc;
 use elan_utils::utils;
 use errors::*;
 use flate2;
@@ -233,9 +233,9 @@ pub fn install(no_prompt: bool, verbose: bool, mut opts: InstallOpts) -> Result<
             do_add_to_path(&get_add_path_methods())?;
         }
         if opts.default_toolchain != "none" {
-            // sanity-check reference
-            let _ = ToolchainDesc::from_str(&opts.default_toolchain)?;
             let ref cfg = common::set_globals(verbose)?;
+            // sanity-check reference
+            let _ = lookup_toolchain_desc(cfg, &opts.default_toolchain)?;
             cfg.set_default(&opts.default_toolchain)?;
         }
 

--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -546,7 +546,7 @@ fn maybe_install_lean(toolchain_str: &str, verbose: bool) -> Result<()> {
     } else if cfg.find_default()?.is_none() {
         let desc = ToolchainDesc::from_str(toolchain_str)?;
         let toolchain = cfg.get_toolchain(&desc, false)?;
-        let status = toolchain.install_from_dist(false)?;
+        let status = toolchain.install_from_dist()?;
         cfg.set_default(&desc)?;
         println!("");
         common::show_channel_update(cfg, &desc, Ok(status))?;

--- a/src/elan-cli/setup_mode.rs
+++ b/src/elan-cli/setup_mode.rs
@@ -32,7 +32,7 @@ pub fn main() -> Result<()> {
             Arg::with_name("default-toolchain")
                 .long("default-toolchain")
                 .takes_value(true)
-                .help("Choose a default toolchain to install"),
+                .help("Choose a default toolchain"),
         )
         .arg(
             Arg::with_name("no-modify-path")

--- a/src/elan-dist/src/component/package.rs
+++ b/src/elan-dist/src/component/package.rs
@@ -8,7 +8,6 @@ extern crate zstd;
 extern crate tar;
 
 use errors::*;
-use temp;
 
 use std::fs::{self, File};
 use std::io::{self, Read, Seek};
@@ -17,9 +16,9 @@ use std::path::{Path, PathBuf};
 use zip::ZipArchive;
 
 #[derive(Debug)]
-pub struct TarPackage<'a>(temp::Dir<'a>);
+pub struct TarPackage();
 
-impl<'a> TarPackage<'a> {
+impl TarPackage {
     pub fn unpack<R: Read>(stream: R, path: &Path) -> Result<()> {
         let mut archive = tar::Archive::new(stream);
         // The lean-installer packages unpack to a directory called
@@ -62,9 +61,9 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
 }
 
 #[derive(Debug)]
-pub struct ZipPackage<'a>(temp::Dir<'a>);
+pub struct ZipPackage();
 
-impl<'a> ZipPackage<'a> {
+impl ZipPackage {
     pub fn unpack<R: Read + Seek>(stream: R, path: &Path) -> Result<()> {
         let mut archive = ZipArchive::new(stream).chain_err(|| ErrorKind::ExtractingPackage)?;
         /*
@@ -132,9 +131,9 @@ impl<'a> ZipPackage<'a> {
 }
 
 #[derive(Debug)]
-pub struct TarGzPackage<'a>(TarPackage<'a>);
+pub struct TarGzPackage();
 
-impl<'a> TarGzPackage<'a> {
+impl TarGzPackage {
     pub fn unpack<R: Read>(stream: R, path: &Path) -> Result<()> {
         let stream = flate2::read::GzDecoder::new(stream);
 
@@ -147,9 +146,9 @@ impl<'a> TarGzPackage<'a> {
 }
 
 #[derive(Debug)]
-pub struct TarZstdPackage<'a>(TarPackage<'a>);
+pub struct TarZstdPackage();
 
-impl<'a> TarZstdPackage<'a> {
+impl TarZstdPackage {
     pub fn unpack<R: Read>(stream: R, path: &Path) -> Result<()> {
         let stream = zstd::stream::read::Decoder::new(stream)?;
 

--- a/src/elan-dist/src/dist.rs
+++ b/src/elan-dist/src/dist.rs
@@ -4,7 +4,6 @@ use errors::*;
 use manifestation::Manifestation;
 use prefix::InstallPrefix;
 use regex::Regex;
-use temp;
 
 use std::fmt;
 
@@ -45,9 +44,6 @@ impl ToolchainDesc {
         }
     }
 }
-
-#[derive(Debug)]
-pub struct Manifest<'a>(temp::File<'a>, String);
 
 impl fmt::Display for ToolchainDesc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/elan-dist/src/dist.rs
+++ b/src/elan-dist/src/dist.rs
@@ -4,7 +4,6 @@ use elan_utils::{self, utils};
 use errors::*;
 use manifest::Component;
 use manifestation::Manifestation;
-use notifications::Notification;
 use prefix::InstallPrefix;
 use temp;
 
@@ -20,70 +19,50 @@ const DEFAULT_ORIGIN: &str = "leanprover/lean4";
 // such as naming their installation directory.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToolchainDesc {
-    // The GitHub source repository to use (if "nightly" is specified, we append "-nightly" to this)
-    // If None, we default to "leanprover/lean"
-    pub origin: Option<String>,
-    // Either "nightly", "stable", an explicit version number, or a tag name
-    pub channel: String,
-    pub date: Option<String>,
+    // The GitHub source repository to use (if "nightly" is specified, we append "-nightly" to this).
+    // Defaults to `DEFAULT_ORIGIN`.
+    pub origin: String,
+    // The release name, usually a Git tag
+    pub release: String,
 }
 
 impl ToolchainDesc {
     pub fn from_str(name: &str) -> Result<Self> {
-        let pattern = r"^(?:([a-zA-Z0-9-]+[/][a-zA-Z0-9-]+)[:])?(?:(nightly|stable)(?:-(\d{4}-\d{2}-\d{2}))?|([a-zA-Z0-9-.]+))$";
+        let pattern = r"^(?:([a-zA-Z0-9-]+[/][a-zA-Z0-9-]+)[:])?([a-zA-Z0-9-.]+)$";
 
         let re = Regex::new(&pattern).unwrap();
         if let Some(c) = re.captures(name) {
-            fn fn_map(s: &str) -> Option<String> {
-                if s == "" {
-                    None
-                } else {
-                    Some(s.to_owned())
-                }
+            let mut origin = c.get(1).map(|s| s.as_str()).unwrap_or(DEFAULT_ORIGIN).to_owned();
+            let mut release = c.get(2).unwrap().as_str().to_owned();
+            if release.starts_with("nightly") && !origin.ends_with("-nightly") {
+                origin = format!("{}-nightly", origin);
             }
-            let origin = c.get(1).map(|s| s.as_str()).and_then(fn_map);
-            let tag = c.get(4).map(|m| m.as_str());
-            if let (Some(ref origin), Some("lean-toolchain")) = (&origin, tag) {
+            if release == "lean-toolchain" {
                 let toolchain_url = format!("https://raw.githubusercontent.com/{}/HEAD/lean-toolchain", origin);
                 return ToolchainDesc::from_str(fetch_url(&toolchain_url)?.trim())
             }
-
-            Ok(ToolchainDesc {
-                origin,
-                channel: c.get(2).map(|s| s.as_str().to_owned()).or(tag.map(|t| t.to_owned())).unwrap(),
-                date: c.get(3).map(|s| s.as_str()).and_then(fn_map),
-            })
+            if release == "stable" || release == "nightly" {
+                release = utils::fetch_latest_release_tag(&origin)?;
+            }
+            if release.starts_with(char::is_numeric) {
+                release = format!("v{}", release)
+            }
+            Ok(ToolchainDesc { origin, release })
         } else {
             Err(ErrorKind::InvalidToolchainName(name.to_string()).into())
         }
     }
 
-    /// Either "$channel" or "channel-$date"
     pub fn manifest_name(&self) -> String {
-        match self.date {
-            None => self.channel.clone(),
-            Some(ref date) => format!("{}-{}", self.channel, date),
-        }
-    }
-
-    pub fn package_dir(&self, dist_root: &str) -> String {
-        match self.date {
-            None => format!("{}", dist_root),
-            Some(ref date) => format!("{}/{}", dist_root, date),
-        }
-    }
-
-    pub fn full_spec(&self) -> String {
-        if self.date.is_some() {
-            format!("{}", self)
-        } else {
-            format!("{} (tracking)", self)
-        }
+        self.release.clone()
     }
 
     pub fn is_tracking(&self) -> bool {
-        let channels = ["nightly", "stable"];
-        channels.iter().any(|x| *x == self.channel) && self.date.is_none()
+        return false
+    }
+
+    fn url(&self) -> String {
+        format!("https://github.com/{}/releases/expanded_assets/{}", self.origin, self.release)
     }
 }
 
@@ -92,17 +71,7 @@ pub struct Manifest<'a>(temp::File<'a>, String);
 
 impl fmt::Display for ToolchainDesc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref origin) = self.origin {
-            write!(f, "{}:", origin)?;
-        }
-
-        write!(f, "{}", &self.channel)?;
-
-        if let Some(ref date) = self.date {
-            write!(f, "-{}", date)?;
-        }
-
-        Ok(())
+        write!(f, "{}:{}", self.origin, self.release)
     }
 }
 
@@ -143,20 +112,6 @@ pub fn update_from_dist<'a>(
     res
 }
 
-//Append "-nightly" to the origin if version == "nightly" was specified.
-//If origin is None use DEFAULT_ORIGIN.
-fn build_origin_name(origin: Option<&String>, version: &str) -> String {
-    let repo = match origin {
-        None => DEFAULT_ORIGIN,
-        Some(repo) => repo,
-    };
-    format!(
-        "{}{}",
-        repo,
-        if version == "nightly" { "-nightly" } else { "" }
-    )
-}
-
 pub fn update_from_dist_<'a>(
     download: DownloadCfg<'a>,
     update_hash: Option<&Path>,
@@ -169,23 +124,7 @@ pub fn update_from_dist_<'a>(
     let toolchain_str = toolchain.to_string();
     let manifestation = Manifestation::open(prefix.clone())?;
 
-    let url = match toolchain_url(download, toolchain) {
-        Ok(url) => url,
-        Err(Error(ErrorKind::Utils(elan_utils::ErrorKind::DownloadNotExists { .. }), _)) => {
-            return Err(format!("no release found for '{}'", toolchain.manifest_name()).into());
-        }
-        Err(e @ Error(ErrorKind::ChecksumFailed { .. }, _)) => {
-            return Err(e);
-        }
-        Err(e) => {
-            return Err(e).chain_err(|| {
-                format!(
-                    "failed to resolve latest version of '{}'",
-                    toolchain.manifest_name()
-                )
-            });
-        }
-    };
+    let url = toolchain.url();
 
     if let Some(hash_file) = update_hash {
         if utils::is_file(hash_file) {
@@ -203,7 +142,7 @@ pub fn update_from_dist_<'a>(
     }
 
     match manifestation.update(
-        &build_origin_name(toolchain.origin.as_ref(), &toolchain.channel),
+        &toolchain.origin,
         &url,
         &download.temp_cfg,
         download.notify_handler.clone(),
@@ -219,32 +158,6 @@ pub fn update_from_dist_<'a>(
         Err(e) => Err(e),
     }
     .map(|()| Some(url))
-}
-
-fn toolchain_url<'a>(download: DownloadCfg<'a>, toolchain: &ToolchainDesc) -> Result<String> {
-    let origin = build_origin_name(toolchain.origin.as_ref(), toolchain.channel.as_ref());
-    Ok(
-        match (toolchain.date.as_ref(), toolchain.channel.as_str()) {
-            (None, version) if version == "stable" || version == "nightly" => {
-                (download.notify_handler)(Notification::DownloadingManifest(version));
-                let release = utils::fetch_latest_release_tag(&origin)?;
-                (download.notify_handler)(Notification::DownloadedManifest(
-                    version,
-                    Some(&release),
-                ));
-                format!("https://github.com/{}/releases/expanded_assets/{}", origin, release)
-            }
-            (Some(date), "nightly") => format!(
-                "https://github.com/{}/releases/expanded_assets/nightly-{}",
-                origin, date
-            ),
-            (None, version) if version.starts_with(|c: char| c.is_numeric()) => {
-                format!("https://github.com/{}/releases/expanded_assets/v{}", origin, version)
-            }
-            (None, tag) => format!("https://github.com/{}/releases/expanded_assets/{}", origin, tag),
-            _ => panic!("wat"),
-        },
-    )
 }
 
 pub fn host_triple() -> &'static str {

--- a/src/elan-dist/src/dist.rs
+++ b/src/elan-dist/src/dist.rs
@@ -54,7 +54,7 @@ impl fmt::Display for ToolchainDesc {
         match self {
             ToolchainDesc::Local { name } => write!(f, "{}", name),
             ToolchainDesc::Remote { origin, release } =>
-                write!(f, "{}/{}", origin, release)
+                write!(f, "{}:{}", origin, release)
         }
     }
 }

--- a/src/elan-dist/src/manifestation.rs
+++ b/src/elan-dist/src/manifestation.rs
@@ -19,7 +19,7 @@ impl Manifestation {
     }
 
     /// Installation using the legacy v1 manifest format
-    pub fn update(
+    pub fn install(
         &self,
         origin: &String,
         url: &String,
@@ -73,17 +73,15 @@ impl Manifestation {
         let installer_file = dlcfg.download_and_check(&url)?;
 
         let prefix = self.prefix.path();
+        dbg!(prefix);
 
         notify_handler(Notification::InstallingComponent("lean"));
 
         // unpack into temporary place, then move atomically to guard against aborts during unpacking
         let unpack_dir = prefix.with_extension("tmp");
 
-        // Remove old files
         if utils::is_directory(prefix) {
-            utils::remove_dir("toolchain directory", prefix, &|n| {
-                (notify_handler)(n.into())
-            })?;
+            return Err(format!("'{}' is already installed", prefix.display()).into())
         }
 
         if utils::is_directory(&unpack_dir) {

--- a/src/elan-dist/src/manifestation.rs
+++ b/src/elan-dist/src/manifestation.rs
@@ -18,7 +18,6 @@ impl Manifestation {
         Ok(Manifestation { prefix })
     }
 
-    /// Installation using the legacy v1 manifest format
     pub fn install(
         &self,
         origin: &String,
@@ -26,8 +25,6 @@ impl Manifestation {
         temp_cfg: &temp::Cfg,
         notify_handler: &dyn Fn(Notification),
     ) -> Result<()> {
-        notify_handler(Notification::DownloadingComponent("lean"));
-
         let dlcfg = DownloadCfg {
             temp_cfg: temp_cfg,
             notify_handler: notify_handler,
@@ -69,12 +66,13 @@ impl Manifestation {
             );
         }
         let url = format!("https://github.com/{}", url.unwrap());
+        notify_handler(Notification::DownloadingComponent(&url));
 
         let installer_file = dlcfg.download_and_check(&url)?;
 
         let prefix = self.prefix.path();
 
-        notify_handler(Notification::InstallingComponent("lean"));
+        notify_handler(Notification::InstallingComponent(&prefix.to_string_lossy()));
 
         // unpack into temporary place, then move atomically to guard against aborts during unpacking
         let unpack_dir = prefix.with_extension("tmp");

--- a/src/elan-dist/src/manifestation.rs
+++ b/src/elan-dist/src/manifestation.rs
@@ -73,7 +73,6 @@ impl Manifestation {
         let installer_file = dlcfg.download_and_check(&url)?;
 
         let prefix = self.prefix.path();
-        dbg!(prefix);
 
         notify_handler(Notification::InstallingComponent("lean"));
 

--- a/src/elan-dist/src/notifications.rs
+++ b/src/elan-dist/src/notifications.rs
@@ -105,9 +105,9 @@ impl<'a> Display for Notification<'a> {
             MissingInstalledComponent(c) => {
                 write!(f, "during uninstall component {} was not found", c)
             }
-            DownloadingComponent(c) => write!(f, "downloading component '{}'", c),
-            InstallingComponent(c) => write!(f, "installing component '{}'", c),
-            RemovingComponent(c) => write!(f, "removing component '{}'", c),
+            DownloadingComponent(c) => write!(f, "downloading {}", c),
+            InstallingComponent(c) => write!(f, "installing {}", c),
+            RemovingComponent(c) => write!(f, "removing {}", c),
             DownloadingManifest(t) => write!(f, "syncing channel updates for '{}'", t),
             DownloadedManifest(date, Some(version)) => {
                 write!(f, "latest update on {}, lean version {}", date, version)

--- a/src/elan-utils/src/errors.rs
+++ b/src/elan-utils/src/errors.rs
@@ -1,5 +1,6 @@
 use download;
 use std::ffi::OsString;
+use std::io;
 use std::path::PathBuf;
 use url::Url;
 
@@ -8,7 +9,9 @@ error_chain! {
         Download(download::Error, download::ErrorKind);
     }
 
-    foreign_links { }
+    foreign_links {
+        Io(io::Error);
+    }
 
     errors {
         LocatingWorkingDir {

--- a/src/elan-utils/src/notifications.rs
+++ b/src/elan-utils/src/notifications.rs
@@ -23,6 +23,7 @@ pub enum Notification<'a> {
     UsingCurl,
     UsingReqwest,
     UsingHyperDeprecated,
+    UsingCachedRelease(&'a str),
 }
 
 impl<'a> Notification<'a> {
@@ -39,7 +40,7 @@ impl<'a> Notification<'a> {
             | ResumingPartialDownload
             | UsingCurl
             | UsingReqwest => NotificationLevel::Verbose,
-            UsingHyperDeprecated | NoCanonicalPath(_) => NotificationLevel::Warn,
+            UsingHyperDeprecated | NoCanonicalPath(_) | UsingCachedRelease(_) => NotificationLevel::Warn,
         }
     }
 }
@@ -67,6 +68,7 @@ impl<'a> Display for Notification<'a> {
             UsingHyperDeprecated => f.write_str(
                 "ELAN_USE_HYPER environment variable is deprecated, use ELAN_USE_REQWEST instead",
             ),
+            UsingCachedRelease(tag) => write!(f, "failed to query latest release, using cached version '{}'", tag),
         }
     }
 }

--- a/src/elan/config.rs
+++ b/src/elan/config.rs
@@ -117,7 +117,7 @@ impl Cfg {
             })?;
         }
 
-        Toolchain::from(self, name)
+        Ok(Toolchain::from(self, name))
     }
 
     pub fn verify_toolchain(&self, name: &ToolchainDesc) -> Result<Toolchain> {

--- a/src/elan/errors.rs
+++ b/src/elan/errors.rs
@@ -16,6 +16,10 @@ error_chain! {
     }
 
     errors {
+        InvalidToolchainName(t: String) {
+            description("invalid toolchain name")
+            display("invalid toolchain name: '{}'", t)
+        }
         UnknownMetadataVersion(v: String) {
             description("unknown metadata version")
             display("unknown metadata version: '{}'", v)

--- a/src/elan/install.rs
+++ b/src/elan/install.rs
@@ -27,7 +27,7 @@ pub fn check_self_update() -> Result<Option<String>> {
     // Get current version
     let current_version = env!("CARGO_PKG_VERSION");
 
-    let tag = fetch_latest_release_tag("leanprover/elan")?;
+    let tag = fetch_latest_release_tag("leanprover/elan", None)?;
     let available_version = &tag[1..];
 
     Ok(if available_version == current_version { None } else { Some(available_version.to_owned()) })

--- a/src/elan/install.rs
+++ b/src/elan/install.rs
@@ -37,12 +37,9 @@ pub fn check_self_update() -> Result<Option<String>> {
 pub enum InstallMethod<'a> {
     Copy(&'a Path),
     Link(&'a Path),
-    // bool is whether to force an update
     Dist(
         &'a dist::ToolchainDesc,
-        Option<&'a Path>,
         DownloadCfg<'a>,
-        bool,
     ),
 }
 
@@ -67,31 +64,19 @@ impl<'a> InstallMethod<'a> {
                 utils::symlink_dir(src, &path, &|n| notify_handler(n.into()))?;
                 Ok(true)
             }
-            InstallMethod::Dist(toolchain, update_hash, dl_cfg, force_update) => {
+            InstallMethod::Dist(toolchain, dl_cfg) => {
                 if let Some(version) = check_self_update()? {
                     notify_handler(Notification::NewVersionAvailable(version));
                 }
 
                 let prefix = &InstallPrefix::from(path.to_owned());
-                let maybe_new_hash = dist::update_from_dist(
+                dist::install_from_dist(
                     dl_cfg,
-                    update_hash,
                     toolchain,
                     prefix,
-                    &[],
-                    &[],
-                    force_update,
                 )?;
 
-                if let Some(hash) = maybe_new_hash {
-                    if let Some(hash_file) = update_hash {
-                        utils::write_file("update hash", hash_file, &hash)?;
-                    }
-
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
+                Ok(true)
             }
         }
     }

--- a/src/elan/notifications.rs
+++ b/src/elan/notifications.rs
@@ -14,7 +14,7 @@ pub enum Notification<'a> {
     Utils(elan_utils::Notification<'a>),
     Temp(temp::Notification<'a>),
 
-    SetDefaultToolchain(&'a ToolchainDesc),
+    SetDefaultToolchain(&'a str),
     SetOverrideToolchain(&'a Path, &'a ToolchainDesc),
     LookingForToolchain(&'a ToolchainDesc),
     ToolchainDirectory(&'a Path, &'a ToolchainDesc),

--- a/src/elan/settings.rs
+++ b/src/elan/settings.rs
@@ -73,7 +73,7 @@ pub enum TelemetryMode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Settings {
     pub version: String,
-    pub default_toolchain: Option<ToolchainDesc>,
+    pub default_toolchain: Option<String>,
     pub overrides: BTreeMap<String, ToolchainDesc>,
     pub telemetry: TelemetryMode,
 }
@@ -140,7 +140,7 @@ impl Settings {
         }
         Ok(Settings {
             version: version,
-            default_toolchain: get_opt_string(&mut table, "default_toolchain", path)?.map(|s| ToolchainDesc::from_str(&s)).map_or(Ok(None), |r| r.map(Some))?,
+            default_toolchain: get_opt_string(&mut table, "default_toolchain", path)?,
             overrides: Self::table_to_overrides(&mut table, path)?,
             telemetry: if get_opt_bool(&mut table, "telemetry", path)?.unwrap_or(false) {
                 TelemetryMode::On
@@ -155,7 +155,7 @@ impl Settings {
         result.insert("version".to_owned(), toml::Value::String(self.version));
 
         if let Some(v) = self.default_toolchain {
-            result.insert("default_toolchain".to_owned(), toml::Value::String(v.to_string()));
+            result.insert("default_toolchain".to_owned(), toml::Value::String(v));
         }
 
         let overrides = Self::overrides_to_table(self.overrides);

--- a/src/elan/settings.rs
+++ b/src/elan/settings.rs
@@ -176,7 +176,7 @@ impl Settings {
 
         for (k, v) in pkg_table {
             if let toml::Value::String(t) = v {
-                result.insert(k, ToolchainDesc::from_str(&t)?);
+                result.insert(k, ToolchainDesc::from_resolved_str(&t)?);
             }
         }
 

--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -241,9 +241,6 @@ impl<'a> Toolchain<'a> {
         Ok(utils::open_browser(&self.doc_path(relative)?)?)
     }
 
-    pub fn make_default(&self) -> Result<()> {
-        self.cfg.set_default(&self.desc)
-    }
     pub fn make_override(&self, path: &Path) -> Result<()> {
         Ok(self.cfg.settings_file.with_mut(|s| {
             s.add_override(path, self.desc.clone(), self.cfg.notify_handler.as_ref());

--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -48,7 +48,8 @@ pub fn lookup_toolchain_desc(cfg: &Cfg, name: &str) -> Result<ToolchainDesc> {
     let re = Regex::new(&pattern).unwrap();
     if let Some(c) = re.captures(name) {
         let mut release = c.get(2).unwrap().as_str().to_owned();
-        if Toolchain::from(cfg, &ToolchainDesc::Local { name: release.clone() }).is_custom() {
+        let local_tc = Toolchain::from(cfg, &ToolchainDesc::Local { name: release.clone() });
+        if local_tc.exists() && local_tc.is_custom() {
             return Ok(ToolchainDesc::Local { name: release })
         }
         let mut origin = c.get(1).map(|s| s.as_str()).unwrap_or(DEFAULT_ORIGIN).to_owned();


### PR DESCRIPTION
This also gets rid of the `update-hashes/` directory (it won't literally get rid of it on existing installs but the contents do not matter anymore).