### PR TITLE
Add glibc dependency check

### DIFF
--- a/elan-init.sh
+++ b/elan-init.sh
@@ -188,6 +188,9 @@ get_architecture() {
         if [ "$(uname -o)" = Android ]; then
             local _ostype=Android
         fi
+        if !(ldd --version 2>&1 | grep -iqE 'glibc|gnu c library|gnu libc'); then
+            err "only glibc systems are supported"
+        fi
     fi
 
     if [ "$_ostype" = Darwin -a "$_cputype" = i386 ]; then


### PR DESCRIPTION
Closes #114.

> But could you first check what upstream rustup does and copy that if applicable?

Reference code: https://github.com/rust-lang/rustup/blob/79e88a2d422afb33acc247ff19c467667f458df7/rustup-init.sh#L309. I made some edits:
- instead of initializing a variable, I raised an error (rust supports musl, lean does not https://github.com/leanprover/lean4/issues/2931);
- this time around we do not want to check if musl is, but if glibc is not.