### PR TITLE
doc: clarify installation instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Lean (version 4.0.0-nightly-2023-06-27, commit bb8cc08de85f, Release)
 curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
 ```
 
-**Windows**: run the following commands in a terminal:
+**Windows**: run the following commands in a terminal (Command Prompt or PowerShell ≥ version 7.4.1):
 ```bash
 curl -O --location https://raw.githubusercontent.com/leanprover/elan/master/elan-init.ps1
 powershell -ExecutionPolicy Bypass -f elan-init.ps1


### PR DESCRIPTION
There's a weird behavior of curl in PowerShell 5.1: when running the first command in the instructions, the created file is named `--location` instead of `elan-init.ps1`.

I checked that curl works properly in Command Prompt or PowerShell 7.4.1. To install elan, Windows users should use Command Prompt or PowerShell ≥ version 7.4.1.

---

This pull request is a revision of https://github.com/leanprover/elan/pull/119. See also the [discussion][0] about this PR in the Lean Zulip chat.

[0]: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/elan.23119.20doc.3A.20fix.20installation.20instructions.20for.20Windows/near/419009910