### PR TITLE
feat: check for self-updates during toolchain downloads

### DIFF
--- a/src/elan-cli/elan_mode.rs
+++ b/src/elan-cli/elan_mode.rs
@@ -289,7 +289,7 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     } else {
         common::update_all_channels(
             cfg,
-            !m.is_present("no-self-update") && !self_update::NEVER_SELF_UPDATE,
+            !m.is_present("no-self-update") && !elan::install::NEVER_SELF_UPDATE,
             m.is_present("force"),
         )?;
     }

--- a/src/elan-dist/src/notifications.rs
+++ b/src/elan-dist/src/notifications.rs
@@ -30,6 +30,7 @@ pub enum Notification<'a> {
     DownloadedManifest(&'a str, Option<&'a str>),
     DownloadingLegacyManifest,
     ManifestChecksumFailedHack,
+    NewVersionAvailable(String),
 }
 
 impl<'a> From<elan_utils::Notification<'a>> for Notification<'a> {
@@ -63,6 +64,7 @@ impl<'a> Notification<'a> {
             | ManifestChecksumFailedHack
             | RollingBack
             | DownloadingManifest(_)
+            | NewVersionAvailable(_)
             | DownloadedManifest(_, _) => NotificationLevel::Info,
             CantReadUpdateHash(_)
             | ExtensionNotInstalled(_)
@@ -116,6 +118,9 @@ impl<'a> Display for Notification<'a> {
             DownloadingLegacyManifest => write!(f, "manifest not found. trying legacy manifest"),
             ManifestChecksumFailedHack => {
                 write!(f, "update not yet available, sorry! try again later")
+            }
+            NewVersionAvailable(ref version) => {
+                write!(f, "Version {version} of elan is available! Use `elan self update` to update.")
             }
         }
     }

--- a/src/elan/lib.rs
+++ b/src/elan/lib.rs
@@ -25,7 +25,7 @@ pub mod command;
 mod config;
 pub mod env_var;
 mod errors;
-mod install;
+pub mod install;
 mod notifications;
 pub mod settings;
 mod toolchain;


### PR DESCRIPTION
```
$ elan toolchain install stable
info: Version 3.0.0 of elan is available! Use `elan self update` to update.
...
```