### PR TITLE
Support for toolchain origins with underscores

### DIFF
--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -37,7 +37,7 @@ pub struct ComponentStatus {
 }
 
 pub fn lookup_toolchain_desc_ext(cfg: &Cfg, name: &str, no_net: bool) -> Result<ToolchainDesc> {
-    let pattern = r"^(?:([a-zA-Z0-9-]+[/][a-zA-Z0-9-]+)[:])?([a-zA-Z0-9-.]+)$";
+    let pattern = r"^(?:([a-zA-Z0-9-_]+[/][a-zA-Z0-9-_]+)[:])?([a-zA-Z0-9-.]+)$";
 
     let re = Regex::new(pattern).unwrap();
     if let Some(c) = re.captures(name) {


### PR DESCRIPTION
related: #99 

Currently, the remote toolchain reference feature on GitHub does not support repositories with underscores in their names. This limitation affects repositories like `leanprover-community/mathematics_in_lean`.