### PR TITLE
chore: more unresolved dump-state output, do not resolve during override lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,8 @@ dependencies = [
  "ole32-sys",
  "regex",
  "remove_dir_all",
+ "serde",
+ "serde_derive",
  "sha2 0.9.9",
  "tar",
  "time",

--- a/src/elan-dist/Cargo.toml
+++ b/src/elan-dist/Cargo.toml
@@ -26,6 +26,8 @@ json = "0.12.4"
 zip = "0.6"
 filetime = "0.2.14"
 time = "0.3"
+serde = "1.0.119"
+serde_derive = "1.0.119"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "sysinfoapi", "tlhelp32", "winnt"] }
@@ -36,4 +38,3 @@ libc = "0.2.88"
 
 [lib]
 name = "elan_dist"
-

--- a/src/elan-dist/src/dist.rs
+++ b/src/elan-dist/src/dist.rs
@@ -4,13 +4,14 @@ use errors::*;
 use manifestation::Manifestation;
 use prefix::InstallPrefix;
 use regex::Regex;
+use serde_derive::Serialize;
 
 use std::{fmt, fs};
 
 // Fully-resolved toolchain descriptors. These always have full target
 // triples attached to them and are used for canonical identification,
 // such as naming their installation directory.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum ToolchainDesc {
     // A linked toolchain
     Local {

--- a/src/elan-dist/src/lib.rs
+++ b/src/elan-dist/src/lib.rs
@@ -14,6 +14,8 @@ extern crate json;
 extern crate sha2;
 extern crate time;
 extern crate zip;
+extern crate serde;
+extern crate serde_derive;
 
 #[cfg(not(windows))]
 extern crate libc;


### PR DESCRIPTION
```
    "default": {
      "unresolved": {
        "Remote": {
          "origin": "leanprover/lean4-nightly",
          "release": "nightly",
          "from_channel": "nightly"
        }
      },
      "resolved": {
        "Ok": "leanprover/lean4-nightly:nightly-2024-11-23"
      }
    },
    "active_override": {
      "unresolved": {
        "Remote": {
          "origin": "leanprover/lean4",
          "release": "stable",
          "from_channel": "stable"
        }
      },
      "reason": "Environment"
    },
    "resolved_active": {
      "Ok": "leanprover/lean4:v4.13.0"
    }
```