### PR TITLE
fix: per-toolchain installation lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "error-chain",
  "filetime",
  "flate2",
+ "fslock",
  "itertools",
  "json",
  "libc",
@@ -621,6 +622,16 @@ dependencies = [
  "libc",
  "nix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/src/elan-dist/Cargo.toml
+++ b/src/elan-dist/Cargo.toml
@@ -26,6 +26,7 @@ json = "0.12.4"
 zip = "0.6"
 filetime = "0.2.14"
 time = "0.3"
+fslock = "0.2.1"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "sysinfoapi", "tlhelp32", "winnt"] }
@@ -36,4 +37,3 @@ libc = "0.2.88"
 
 [lib]
 name = "elan_dist"
-

--- a/src/elan-dist/src/lib.rs
+++ b/src/elan-dist/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "1024"]
 
+extern crate fslock;
 extern crate elan_utils;
 extern crate flate2;
 extern crate itertools;

--- a/src/elan-dist/src/notifications.rs
+++ b/src/elan-dist/src/notifications.rs
@@ -31,6 +31,7 @@ pub enum Notification<'a> {
     DownloadingLegacyManifest,
     ManifestChecksumFailedHack,
     NewVersionAvailable(String),
+    WaitingForFileLock(&'a Path, &'a str),
 }
 
 impl<'a> From<elan_utils::Notification<'a>> for Notification<'a> {
@@ -65,6 +66,7 @@ impl<'a> Notification<'a> {
             | RollingBack
             | DownloadingManifest(_)
             | NewVersionAvailable(_)
+            | WaitingForFileLock(_, _)
             | DownloadedManifest(_, _) => NotificationLevel::Info,
             CantReadUpdateHash(_)
             | ExtensionNotInstalled(_)
@@ -124,6 +126,9 @@ impl<'a> Display for Notification<'a> {
                     f,
                     "Version {version} of elan is available! Use `elan self update` to update."
                 )
+            }
+            WaitingForFileLock(path, pid) => {
+                write!(f, "waiting for previous installation request to finish ({}, held by PID {})", path.display(), pid)
             }
         }
     }


### PR DESCRIPTION
```
$ elan install nightly
info: waiting for previous installation request to finish (/home/sebastian/.elan/toolchains/leanprover--lean4-nightly---nightly-2024-11-23.lock, held by PID 2508083
)

leanprover/lean4-nightly:nightly-2024-11-23 installed
```