### PR TITLE
feat: differentiate live and cached toolchain resolution in `dump-state`

### DIFF
--- a/src/elan/config.rs
+++ b/src/elan/config.rs
@@ -235,7 +235,7 @@ impl Cfg {
         path: &Path,
     ) -> Result<Option<(Toolchain, Option<OverrideReason>)>> {
         if let Some((toolchain, reason)) = self.find_override(path)? {
-            let toolchain = resolve_toolchain_desc(&self, &toolchain, false)?;
+            let toolchain = resolve_toolchain_desc(&self, &toolchain)?;
             match self.get_toolchain(&toolchain, false) {
                 Ok(toolchain) => {
                     if toolchain.exists() {


### PR DESCRIPTION
```
$ elan dump-state
    "default": {
      "unresolved": {
        "Remote": {
          "origin": "leanprover/lean4",
          "release": "stable",
          "from_channel": "stable"
        }
      },
      "resolved": {
        "live": {
          "Ok": "leanprover/lean4:v4.14.0"
        },
        "cached": {
          "Ok": "leanprover/lean4:v4.9.0"
        }
      }
    },
    "active_override": null,
    "resolved_active": {
      "live": {
        "Ok": "leanprover/lean4:v4.14.0"
      },
      "cached": {
        "Ok": "leanprover/lean4:v4.9.0"
      }
    }
```
```
$ elan dump-state --no-net
    "default": {
      "unresolved": {
        "Remote": {
          "origin": "leanprover/lean4",
          "release": "stable",
          "from_channel": "stable"
        }
      },
      "resolved": {
        "live": {
          "Err": "Cannot fetch latest release tag under `--no-net`"
        },
        "cached": {
          "Ok": "leanprover/lean4:v4.9.0"
        }
      }
    },
    "active_override": null,
    "resolved_active": {
      "live": {
        "Err": "Cannot fetch latest release tag under `--no-net`"
      },
      "cached": {
        "Ok": "leanprover/lean4:v4.9.0"
      }
    }
```