### PR TITLE
Use Rust 2021 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "elan"
 version = "4.0.0-pre"
 authors = [ "Sebastian Ullrich <sebasti@nullri.ch>" ]
 description = "Manage multiple Lean installations with ease"
+edition = "2021"
 publish = false
 
 license = "MIT OR Apache-2.0"

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -3,6 +3,7 @@
 name = "download"
 version = "0.4.0"
 authors = [ "Brian Anderson <banderson@mozilla.com>" ]
+edition = "2021"
 
 license = "MIT/Apache-2.0"
 

--- a/src/download/src/errors.rs
+++ b/src/download/src/errors.rs
@@ -1,3 +1,5 @@
+use error_chain::error_chain;
+
 error_chain! {
     links { }
 

--- a/src/elan-cli/common.rs
+++ b/src/elan-cli/common.rs
@@ -1,17 +1,16 @@
 //! Just a dumping ground for cli stuff
 
+use crate::errors::*;
+use crate::term2;
 use elan::{Cfg, Notification, Toolchain};
 use elan_dist::dist::ToolchainDesc;
 use elan_utils::notify::NotificationLevel;
 use elan_utils::utils;
-use errors::*;
-use std;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
-use term2;
 use wait_timeout::ChildExt;
 
 pub fn confirm(question: &str, default: bool) -> Result<bool> {
@@ -101,12 +100,12 @@ pub fn read_line() -> Result<String> {
 }
 
 pub fn set_globals(verbose: bool) -> Result<Cfg> {
-    use download_tracker::DownloadTracker;
+    use crate::download_tracker::DownloadTracker;
     use std::cell::RefCell;
 
     let download_tracker = RefCell::new(DownloadTracker::new());
 
-    Ok(Cfg::from_env(Arc::new(move |n: Notification| {
+    Ok(Cfg::from_env(Arc::new(move |n: Notification<'_>| {
         if download_tracker.borrow_mut().handle_notification(&n) {
             return;
         }
@@ -153,7 +152,7 @@ pub fn show_channel_update(cfg: &Cfg, desc: &ToolchainDesc) -> Result<()> {
     Ok(())
 }
 
-pub fn lean_version(toolchain: &Toolchain) -> String {
+pub fn lean_version(toolchain: &Toolchain<'_>) -> String {
     if toolchain.exists() {
         let lean_path = toolchain.binary_file("lean");
         if utils::is_file(&lean_path) {

--- a/src/elan-cli/download_tracker.rs
+++ b/src/elan-cli/download_tracker.rs
@@ -4,7 +4,6 @@ use elan_utils::tty;
 use elan_utils::Notification as Un;
 use std::collections::VecDeque;
 use std::fmt;
-use term;
 use time::OffsetDateTime;
 
 /// Keep track of this many past download amounts
@@ -53,7 +52,7 @@ impl DownloadTracker {
         }
     }
 
-    pub fn handle_notification(&mut self, n: &Notification) -> bool {
+    pub fn handle_notification(&mut self, n: &Notification<'_>) -> bool {
         match *n {
             Notification::Install(In::Utils(Un::DownloadContentLengthReceived(content_len))) => {
                 self.content_length_received(content_len);
@@ -178,7 +177,7 @@ impl DownloadTracker {
 struct HumanReadable(f64);
 
 impl fmt::Display for HumanReadable {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             // repurposing the alternate mode for ETA
             let sec = self.0;

--- a/src/elan-cli/errors.rs
+++ b/src/elan-cli/errors.rs
@@ -3,9 +3,8 @@
 use std::io;
 use std::path::PathBuf;
 
-use elan;
 use elan_dist::{self, temp};
-use elan_utils;
+use error_chain::error_chain;
 
 error_chain! {
     links {

--- a/src/elan-cli/job.rs
+++ b/src/elan-cli/job.rs
@@ -34,8 +34,6 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate winapi;
-
     use std::ffi::OsString;
     use std::io;
     use std::mem;

--- a/src/elan-cli/json_dump.rs
+++ b/src/elan-cli/json_dump.rs
@@ -1,4 +1,8 @@
-use elan::{lookup_unresolved_toolchain_desc, resolve_toolchain_desc_ext, utils::{self, fetch_latest_release_tag}, Cfg, Toolchain, UnresolvedToolchainDesc};
+use elan::{
+    lookup_unresolved_toolchain_desc, resolve_toolchain_desc_ext,
+    utils::{self, fetch_latest_release_tag},
+    Cfg, Toolchain, UnresolvedToolchainDesc,
+};
 use std::{io, path::PathBuf};
 
 use serde_derive::Serialize;
@@ -61,33 +65,46 @@ pub struct StateDump {
     toolchains: Toolchains,
 }
 
-fn mk_toolchain_resolution(cfg: &Cfg, unresolved: &UnresolvedToolchainDesc, no_net: bool) -> ToolchainResolution {
-    let live = resolve_toolchain_desc_ext(cfg, unresolved, no_net, false).map(|t| t.to_string()).map_err(|e| e.to_string());
-    let cached = resolve_toolchain_desc_ext(cfg, unresolved, true, true).map(|t| t.to_string()).map_err(|e| e.to_string()).ok();
+fn mk_toolchain_resolution(
+    cfg: &Cfg,
+    unresolved: &UnresolvedToolchainDesc,
+    no_net: bool,
+) -> ToolchainResolution {
+    let live = resolve_toolchain_desc_ext(cfg, unresolved, no_net, false)
+        .map(|t| t.to_string())
+        .map_err(|e| e.to_string());
+    let cached = resolve_toolchain_desc_ext(cfg, unresolved, true, true)
+        .map(|t| t.to_string())
+        .map_err(|e| e.to_string())
+        .ok();
     ToolchainResolution { live, cached }
 }
 
 impl StateDump {
     pub fn new(cfg: &Cfg, no_net: bool) -> crate::Result<StateDump> {
         let newest = fetch_latest_release_tag("leanprover/elan", no_net);
-        let ref cwd = utils::current_dir()?;
+        let cwd = &(utils::current_dir()?);
         let active_override = cfg.find_override(cwd)?;
         let default = match cfg.get_default()? {
             None => None,
-            Some(d) => Some(lookup_unresolved_toolchain_desc(cfg, &d)?)
+            Some(d) => Some(lookup_unresolved_toolchain_desc(cfg, &d)?),
         };
         Ok(StateDump {
             elan_version: Version {
                 current: env!("CARGO_PKG_VERSION").to_string(),
-                newest: newest.map(|s| s.trim_start_matches('v').to_string()).map_err(|e| e.to_string()),
+                newest: newest
+                    .map(|s| s.trim_start_matches('v').to_string())
+                    .map_err(|e| e.to_string()),
             },
             toolchains: Toolchains {
-                installed: cfg.list_toolchains()?
+                installed: cfg
+                    .list_toolchains()?
                     .into_iter()
                     .map(|t| InstalledToolchain {
                         resolved_name: t.to_string(),
                         path: Toolchain::from(cfg, &t).path().to_owned(),
-                    }).collect(),
+                    })
+                    .collect(),
                 default: default.as_ref().map(|default| DefaultToolchain {
                     unresolved: default.clone(),
                     resolved: mk_toolchain_resolution(cfg, default, no_net),
@@ -99,7 +116,7 @@ impl StateDump {
                 resolved_active: active_override
                     .map(|p| p.0)
                     .or(default)
-                    .map(|t| mk_toolchain_resolution(cfg, &t, no_net))
+                    .map(|t| mk_toolchain_resolution(cfg, &t, no_net)),
             },
         })
     }

--- a/src/elan-cli/log.rs
+++ b/src/elan-cli/log.rs
@@ -1,6 +1,6 @@
+use crate::term2;
 use std::fmt;
 use std::io::Write;
-use term2;
 
 macro_rules! warn {
     ( $ ( $ arg : tt ) * ) => ( $crate::log::warn_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
@@ -16,7 +16,7 @@ macro_rules! verbose {
     ( $ ( $ arg : tt ) * ) => ( $crate::log::verbose_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
-pub fn warn_fmt(args: fmt::Arguments) {
+pub fn warn_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_YELLOW);
     let _ = t.attr(term2::Attr::Bold);
@@ -26,7 +26,7 @@ pub fn warn_fmt(args: fmt::Arguments) {
     let _ = writeln!(t);
 }
 
-pub fn err_fmt(args: fmt::Arguments) {
+pub fn err_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_RED);
     let _ = t.attr(term2::Attr::Bold);
@@ -36,7 +36,7 @@ pub fn err_fmt(args: fmt::Arguments) {
     let _ = writeln!(t);
 }
 
-pub fn info_fmt(args: fmt::Arguments) {
+pub fn info_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
     let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "info: ");
@@ -45,7 +45,7 @@ pub fn info_fmt(args: fmt::Arguments) {
     let _ = writeln!(t);
 }
 
-pub fn verbose_fmt(args: fmt::Arguments) {
+pub fn verbose_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_MAGENTA);
     let _ = t.attr(term2::Attr::Bold);

--- a/src/elan-cli/main.rs
+++ b/src/elan-cli/main.rs
@@ -13,39 +13,7 @@
 //! different name.
 
 #![recursion_limit = "1024"]
-
-extern crate elan_dist;
-extern crate elan_utils;
-#[macro_use]
-extern crate error_chain;
-
-extern crate clap;
-extern crate elan;
-extern crate flate2;
-extern crate itertools;
-extern crate json;
-extern crate markdown;
-extern crate rand;
-extern crate regex;
-extern crate same_file;
-extern crate scopeguard;
-extern crate sha2;
-extern crate tar;
-extern crate tempfile;
-extern crate term;
-extern crate time;
-extern crate toml;
-extern crate wait_timeout;
-extern crate zip;
-extern crate serde_derive;
-
-#[cfg(windows)]
-extern crate gcc;
-extern crate libc;
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate winreg;
+#![deny(rust_2018_idioms)]
 
 #[macro_use]
 mod log;
@@ -55,11 +23,11 @@ mod elan_mode;
 mod errors;
 mod help;
 mod job;
+mod json_dump;
 mod proxy_mode;
 mod self_update;
 mod setup_mode;
 mod term2;
-mod json_dump;
 
 use elan::env_var::LEAN_RECURSION_COUNT_MAX;
 use errors::*;

--- a/src/elan-cli/proxy_mode.rs
+++ b/src/elan-cli/proxy_mode.rs
@@ -1,15 +1,15 @@
-use common::set_globals;
+use crate::common::set_globals;
+use crate::errors::*;
+use crate::job;
 use elan::command::run_command_for_dir;
 use elan::{lookup_toolchain_desc, Cfg};
 use elan_utils::utils;
-use errors::*;
-use job;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub fn main() -> Result<()> {
-    ::self_update::cleanup_self_updater()?;
+    crate::self_update::cleanup_self_updater()?;
 
     let _setup = job::setup();
 

--- a/src/elan-cli/setup_mode.rs
+++ b/src/elan-cli/setup_mode.rs
@@ -1,7 +1,7 @@
+use crate::common;
+use crate::errors::*;
+use crate::self_update::{self, InstallOpts};
 use clap::{App, AppSettings, Arg};
-use common;
-use errors::*;
-use self_update::{self, InstallOpts};
 use std::env;
 
 pub fn main() -> Result<()> {

--- a/src/elan-cli/term2.rs
+++ b/src/elan-cli/term2.rs
@@ -6,7 +6,6 @@ use elan_utils::tty;
 use markdown::tokenize;
 use markdown::{Block, ListItem, Span};
 use std::io;
-use term;
 
 pub use term::color;
 pub use term::Attr;
@@ -58,7 +57,7 @@ pub fn stderr() -> StderrTerminal {
 }
 
 // Handles the wrapping of text written to the console
-struct LineWrapper<'a, T: io::Write + 'a> {
+struct LineWrapper<'a, T: io::Write> {
     indent: u32,
     margin: u32,
     pos: u32,
@@ -136,7 +135,7 @@ impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
 }
 
 // Handles the formatting of text
-struct LineFormatter<'a, T: Instantiable + Isatty + io::Write + 'a> {
+struct LineFormatter<'a, T: Instantiable + Isatty + io::Write> {
     wrapper: LineWrapper<'a, Terminal<T>>,
     attrs: Vec<Attr>,
 }

--- a/src/elan-dist/Cargo.toml
+++ b/src/elan-dist/Cargo.toml
@@ -5,6 +5,7 @@ version = "1.11.0"
 authors = [ "Sebastian Ullrich <sebasti@nullri.ch>" ]
 description = "Installation from a Lean distribution server"
 build = "build.rs"
+edition = "2021"
 
 license = "MIT OR Apache-2.0"
 

--- a/src/elan-dist/src/component/package.rs
+++ b/src/elan-dist/src/component/package.rs
@@ -2,12 +2,7 @@
 //! for installing from a directory or tarball to an installation
 //! prefix, represented by a `Components` instance.
 
-extern crate filetime;
-extern crate flate2;
-extern crate tar;
-extern crate zstd;
-
-use errors::*;
+use crate::errors::*;
 
 use std::fs::{self, File};
 use std::io::{self, Read, Seek};

--- a/src/elan-dist/src/config.rs
+++ b/src/elan-dist/src/config.rs
@@ -1,8 +1,8 @@
 use toml;
 
 use super::manifest::Component;
+use crate::errors::*;
 use elan_utils::toml_utils::*;
-use errors::*;
 
 pub const SUPPORTED_CONFIG_VERSIONS: [&'static str; 1] = ["1"];
 pub const DEFAULT_CONFIG_VERSION: &'static str = "1";

--- a/src/elan-dist/src/download.rs
+++ b/src/elan-dist/src/download.rs
@@ -1,7 +1,7 @@
+use crate::errors::*;
+use crate::notifications::*;
+use crate::temp;
 use elan_utils::utils;
-use errors::*;
-use notifications::*;
-use temp;
 
 use std::ops;
 use std::path::{Path, PathBuf};
@@ -11,7 +11,7 @@ const _UPDATE_HASH_LEN: usize = 20;
 #[derive(Copy, Clone)]
 pub struct DownloadCfg<'a> {
     pub temp_cfg: &'a temp::Cfg,
-    pub notify_handler: &'a dyn Fn(Notification),
+    pub notify_handler: &'a dyn Fn(Notification<'_>),
 }
 
 pub struct File {

--- a/src/elan-dist/src/errors.rs
+++ b/src/elan-dist/src/errors.rs
@@ -1,8 +1,9 @@
+use crate::manifest::Component;
+use crate::temp;
 use elan_utils;
-use manifest::Component;
+use error_chain::error_chain;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use temp;
 use time::error::ComponentRange;
 use toml;
 

--- a/src/elan-dist/src/lib.rs
+++ b/src/elan-dist/src/lib.rs
@@ -1,29 +1,5 @@
 #![recursion_limit = "1024"]
-
-extern crate fslock;
-extern crate elan_utils;
-extern crate flate2;
-extern crate itertools;
-extern crate regex;
-extern crate tar;
-extern crate toml;
-extern crate url;
-extern crate walkdir;
-#[macro_use]
-extern crate error_chain;
-extern crate json;
-extern crate sha2;
-extern crate time;
-extern crate zip;
-extern crate serde;
-extern crate serde_derive;
-
-#[cfg(not(windows))]
-extern crate libc;
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate winreg;
+#![deny(rust_2018_idioms)]
 
 pub use errors::*;
 pub use notifications::Notification;

--- a/src/elan-dist/src/manifest.rs
+++ b/src/elan-dist/src/manifest.rs
@@ -10,8 +10,8 @@
 //!
 //! See tests/channel-lean-nightly-example.toml for an example.
 
+use crate::errors::*;
 use elan_utils::toml_utils::*;
-use errors::*;
 use toml;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/src/elan-dist/src/notifications.rs
+++ b/src/elan-dist/src/notifications.rs
@@ -1,10 +1,10 @@
+use crate::errors::*;
+use crate::manifest::Component;
+use crate::temp;
 use elan_utils;
 use elan_utils::notify::NotificationLevel;
-use errors::*;
-use manifest::Component;
 use std::fmt::{self, Display};
 use std::path::Path;
-use temp;
 
 #[derive(Debug)]
 pub enum Notification<'a> {
@@ -78,7 +78,7 @@ impl<'a> Notification<'a> {
 }
 
 impl<'a> Display for Notification<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Notification::*;
         match *self {
             Temp(ref n) => n.fmt(f),
@@ -128,7 +128,12 @@ impl<'a> Display for Notification<'a> {
                 )
             }
             WaitingForFileLock(path, pid) => {
-                write!(f, "waiting for previous installation request to finish ({}, held by PID {})", path.display(), pid)
+                write!(
+                    f,
+                    "waiting for previous installation request to finish ({}, held by PID {})",
+                    path.display(),
+                    pid
+                )
             }
         }
     }

--- a/src/elan-dist/src/temp.rs
+++ b/src/elan-dist/src/temp.rs
@@ -1,5 +1,3 @@
-extern crate remove_dir_all;
-
 use elan_utils::raw;
 use std::error;
 use std::fmt::{self, Display};
@@ -30,7 +28,7 @@ pub enum Notification<'a> {
 
 pub struct Cfg {
     root_directory: PathBuf,
-    notify_handler: Box<dyn Fn(Notification)>,
+    notify_handler: Box<dyn Fn(Notification<'_>)>,
 }
 
 #[derive(Debug)]
@@ -62,7 +60,7 @@ impl<'a> Notification<'a> {
 }
 
 impl<'a> Display for Notification<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Notification::*;
         match *self {
             CreatingRoot(path) => write!(f, "creating temp root: {}", path.display()),
@@ -107,7 +105,7 @@ impl error::Error for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Error::*;
         match *self {
             CreatingRoot { ref path, error: _ } => {
@@ -124,7 +122,7 @@ impl Display for Error {
 }
 
 impl Cfg {
-    pub fn new(root_directory: PathBuf, notify_handler: Box<dyn Fn(Notification)>) -> Self {
+    pub fn new(root_directory: PathBuf, notify_handler: Box<dyn Fn(Notification<'_>)>) -> Self {
         Cfg {
             root_directory: root_directory,
             notify_handler: notify_handler,
@@ -141,7 +139,7 @@ impl Cfg {
         })
     }
 
-    pub fn new_directory(&self) -> Result<Dir> {
+    pub fn new_directory(&self) -> Result<Dir<'_>> {
         self.create_root()?;
 
         loop {
@@ -165,11 +163,11 @@ impl Cfg {
         }
     }
 
-    pub fn new_file(&self) -> Result<File> {
+    pub fn new_file(&self) -> Result<File<'_>> {
         self.new_file_with_ext("", "")
     }
 
-    pub fn new_file_with_ext(&self, prefix: &str, ext: &str) -> Result<File> {
+    pub fn new_file_with_ext(&self, prefix: &str, ext: &str) -> Result<File<'_>> {
         self.create_root()?;
 
         loop {
@@ -195,7 +193,7 @@ impl Cfg {
 }
 
 impl fmt::Debug for Cfg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Cfg")
             .field("root_directory", &self.root_directory)
             .field("notify_handler", &"...")

--- a/src/elan-utils/Cargo.toml
+++ b/src/elan-utils/Cargo.toml
@@ -4,6 +4,7 @@ name = "elan-utils"
 version = "1.11.0"
 authors = [ "Sebastian Ullrich <sebasti@nullri.ch>" ]
 description = "Utility functions for elan"
+edition = "2021"
 
 license = "MIT OR Apache-2.0"
 

--- a/src/elan-utils/src/errors.rs
+++ b/src/elan-utils/src/errors.rs
@@ -1,4 +1,5 @@
-use download;
+use error_chain::error_chain;
+
 use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;

--- a/src/elan-utils/src/lib.rs
+++ b/src/elan-utils/src/lib.rs
@@ -1,25 +1,5 @@
 #![recursion_limit = "1024"] // for error_chain!
-
-extern crate rand;
-extern crate scopeguard;
-#[macro_use]
-extern crate error_chain;
-extern crate curl;
-extern crate dirs;
-extern crate download;
-extern crate regex;
-extern crate semver;
-extern crate sha2;
-extern crate toml;
-extern crate url;
-
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate winreg;
-
-#[cfg(unix)]
-extern crate libc;
+#![deny(rust_2018_idioms)]
 
 pub mod errors;
 pub mod notifications;

--- a/src/elan-utils/src/notifications.rs
+++ b/src/elan-utils/src/notifications.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use url::Url;
 
-use notify::NotificationLevel;
+use crate::notify::NotificationLevel;
 
 #[derive(Debug)]
 pub enum Notification<'a> {
@@ -39,15 +39,13 @@ impl<'a> Notification<'a> {
             | ResumingPartialDownload
             | UsingCurl
             | UsingReqwest => NotificationLevel::Verbose,
-            UsingHyperDeprecated | NoCanonicalPath(_) => {
-                NotificationLevel::Warn
-            }
+            UsingHyperDeprecated | NoCanonicalPath(_) => NotificationLevel::Warn,
         }
     }
 }
 
 impl<'a> Display for Notification<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Notification::*;
         match *self {
             CreatingDirectory(name, path) => {

--- a/src/elan-utils/src/raw.rs
+++ b/src/elan-utils/src/raw.rs
@@ -1,5 +1,3 @@
-extern crate remove_dir_all;
-
 use std::char::from_u32;
 use std::env;
 use std::error;
@@ -288,7 +286,7 @@ impl error::Error for CommandError {
 }
 
 impl fmt::Display for CommandError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CommandError::Io(ref e) => write!(f, "Io: {}", e),
             CommandError::Status(ref s) => write!(f, "Status: {}", s),

--- a/src/elan-utils/src/toml_utils.rs
+++ b/src/elan-utils/src/toml_utils.rs
@@ -1,4 +1,4 @@
-use errors::*;
+use crate::errors::*;
 use toml;
 
 pub fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {

--- a/src/elan/command.rs
+++ b/src/elan/command.rs
@@ -2,8 +2,8 @@ use std::ffi::OsStr;
 use std::io;
 use std::process::{self, Command};
 
+use crate::errors::*;
 use elan_utils;
-use errors::*;
 
 pub fn run_command_for_dir<S: AsRef<OsStr>>(
     mut cmd: Command,

--- a/src/elan/errors.rs
+++ b/src/elan/errors.rs
@@ -1,9 +1,9 @@
 use elan_dist::dist::ToolchainDesc;
 use elan_dist::manifest::Component;
 use elan_dist::{self, temp};
-use elan_utils;
 use std::path::PathBuf;
-use toml;
+
+use error_chain::error_chain;
 
 error_chain! {
     links {

--- a/src/elan/install.rs
+++ b/src/elan/install.rs
@@ -1,12 +1,12 @@
 //! Installation and upgrade of both distribution-managed and local
 //! toolchains
 
+use crate::errors::Result;
 use elan_dist::dist;
 use elan_dist::download::DownloadCfg;
 use elan_dist::prefix::InstallPrefix;
 use elan_dist::Notification;
 use elan_utils::utils::{self, fetch_latest_release_tag};
-use errors::Result;
 use std::path::Path;
 
 #[cfg(feature = "no-self-update")]
@@ -43,8 +43,8 @@ pub enum InstallMethod<'a> {
     Dist(&'a dist::ToolchainDesc, DownloadCfg<'a>),
 }
 
-impl<'a> InstallMethod<'a> {
-    pub fn run(self, path: &Path, notify_handler: &dyn Fn(Notification)) -> Result<()> {
+impl InstallMethod<'_> {
+    pub fn run(self, path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
         if path.exists() {
             // Don't uninstall first for Dist method
             match self {
@@ -78,7 +78,7 @@ impl<'a> InstallMethod<'a> {
     }
 }
 
-pub fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification)) -> Result<()> {
+pub fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
     Ok(utils::remove_dir("install", path, &|n| {
         notify_handler(n.into())
     })?)

--- a/src/elan/lib.rs
+++ b/src/elan/lib.rs
@@ -1,24 +1,9 @@
 #![recursion_limit = "1024"]
+#![deny(rust_2018_idioms)]
 
-extern crate elan_dist;
-extern crate elan_utils;
-#[macro_use]
-extern crate error_chain;
-extern crate itertools;
-#[cfg(unix)]
-extern crate libc;
-extern crate regex;
-extern crate semver;
-extern crate serde_derive;
-extern crate serde_json;
-extern crate tempfile;
-extern crate time;
-extern crate toml;
-extern crate url;
-
+pub use crate::errors::*;
 pub use config::*;
 pub use elan_utils::{notify, toml_utils, utils};
-pub use errors::*;
 pub use notifications::*;
 pub use toolchain::*;
 

--- a/src/elan/notifications.rs
+++ b/src/elan/notifications.rs
@@ -1,11 +1,10 @@
 use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 
+use crate::errors::*;
 use elan_dist::dist::ToolchainDesc;
-use errors::*;
 
 use elan_dist::{self, temp};
-use elan_utils;
 use elan_utils::notify::NotificationLevel;
 
 #[derive(Debug)]
@@ -56,7 +55,7 @@ impl<'a> From<temp::Notification<'a>> for Notification<'a> {
     }
 }
 
-impl<'a> Notification<'a> {
+impl Notification<'_> {
     pub fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match *self {
@@ -83,13 +82,15 @@ impl<'a> Notification<'a> {
             | MetadataUpgradeNotNeeded(_)
             | SetTelemetry(_) => NotificationLevel::Info,
             NonFatalError(_) => NotificationLevel::Error,
-            UpgradeRemovesToolchains | MissingFileDuringSelfUninstall(_) | UsingExistingRelease(_) => NotificationLevel::Warn,
+            UpgradeRemovesToolchains
+            | MissingFileDuringSelfUninstall(_)
+            | UsingExistingRelease(_) => NotificationLevel::Warn,
         }
     }
 }
 
-impl<'a> Display for Notification<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+impl Display for Notification<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Notification::*;
         match *self {
             Install(ref n) => n.fmt(f),
@@ -111,7 +112,11 @@ impl<'a> Display for Notification<'a> {
             InstalledToolchain(name) => write!(f, "toolchain '{}' installed", name),
             UsingExistingToolchain(name) => write!(f, "using existing install for '{}'", name),
             UninstallingToolchain(name) => write!(f, "uninstalling toolchain '{}'", name),
-            UninstallingObsoleteToolchain(name) => write!(f, "uninstalling toolchain '{}' using obsolete format", name.display()),
+            UninstallingObsoleteToolchain(name) => write!(
+                f,
+                "uninstalling toolchain '{}' using obsolete format",
+                name.display()
+            ),
             UninstalledToolchain(name) => write!(f, "toolchain '{}' uninstalled", name),
             ToolchainNotInstalled(name) => write!(f, "no toolchain installed for '{}'", name),
             UpdateHashMatches => {
@@ -150,9 +155,8 @@ impl<'a> Display for Notification<'a> {
             UsingExistingRelease(tc) => write!(
                 f,
                 "failed to query latest release, using existing version '{}'",
-                tc.to_string()
+                tc
             ),
-
         }
     }
 }

--- a/src/elan/settings.rs
+++ b/src/elan/settings.rs
@@ -1,12 +1,12 @@
+use crate::errors::*;
+use crate::notifications::*;
+use crate::toml_utils::*;
+use crate::utils;
 use elan_dist::dist::ToolchainDesc;
-use errors::*;
-use notifications::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use toml;
-use toml_utils::*;
-use utils;
 
 pub const SUPPORTED_METADATA_VERSIONS: [&str; 2] = ["2", "12"];
 pub const DEFAULT_METADATA_VERSION: &str = "12";
@@ -90,7 +90,7 @@ impl Default for Settings {
 }
 
 impl Settings {
-    fn path_to_key(path: &Path, notify_handler: &dyn Fn(Notification)) -> String {
+    fn path_to_key(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> String {
         if path.exists() {
             utils::canonicalize_path(path, &|n| notify_handler(n.into()))
                 .display()
@@ -100,7 +100,11 @@ impl Settings {
         }
     }
 
-    pub fn remove_override(&mut self, path: &Path, notify_handler: &dyn Fn(Notification)) -> bool {
+    pub fn remove_override(
+        &mut self,
+        path: &Path,
+        notify_handler: &dyn Fn(Notification<'_>),
+    ) -> bool {
         let key = Self::path_to_key(path, notify_handler);
         self.overrides.remove(&key).is_some()
     }
@@ -109,7 +113,7 @@ impl Settings {
         &mut self,
         path: &Path,
         toolchain: ToolchainDesc,
-        notify_handler: &dyn Fn(Notification),
+        notify_handler: &dyn Fn(Notification<'_>),
     ) {
         let key = Self::path_to_key(path, notify_handler);
         notify_handler(Notification::SetOverrideToolchain(path, &toolchain));
@@ -119,7 +123,7 @@ impl Settings {
     pub fn dir_override(
         &self,
         dir: &Path,
-        notify_handler: &dyn Fn(Notification),
+        notify_handler: &dyn Fn(Notification<'_>),
     ) -> Option<ToolchainDesc> {
         let key = Self::path_to_key(dir, notify_handler);
         self.overrides.get(&key).cloned()


### PR DESCRIPTION
Hi there! I am a happy user of both elan and Lean. While building locally, I noticed elan still uses the 2018 edition of Rust. I've done the (almost entirely mechanistic) translation to Rust 2021 edition. I've tested it with vanilla Cargo and in the flake, and it works. This change doesn't add much value to end users but it sure makes it nicer to hack on elan.