### PR TITLE
Improve error reporting in elan-init.ps1

### DIFF
--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -58,6 +58,7 @@ try {
 }
 catch {
     Write-Host "Download failed for ${DownloadUrl}"
+    Write-Host $_
     return 1
 }
 


### PR DESCRIPTION
If the download fails the script currently throws away the exception information and prints a generic error. This changes it to also print the exception.