### PR TITLE
hack: permit `foo/bar/baz:version` in toolchain names

### DIFF
--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -41,7 +41,7 @@ pub struct ComponentStatus {
 pub struct UnresolvedToolchainDesc(pub ToolchainDesc);
 
 pub fn lookup_unresolved_toolchain_desc(cfg: &Cfg, name: &str) -> Result<UnresolvedToolchainDesc> {
-    let pattern = r"^(?:([a-zA-Z0-9-_]+[/][a-zA-Z0-9-_]+)[:])?([a-zA-Z0-9-.]+)$";
+    let pattern = r"^(?:((?:[a-zA-Z0-9-_]+[/])*[a-zA-Z0-9-_]+)[:])?([a-zA-Z0-9-.]+)$";
 
     let re = Regex::new(pattern).unwrap();
     if let Some(c) = re.captures(name) {


### PR DESCRIPTION
This was legal (accidentally?) in previous elan version, and let me smuggle [Bazel labels](https://bazel.build/concepts/labels) into the `lean-toolchain` files.

[Look, my setup works for me. Just add an option to reenable ...](https://xkcd.com/1172)

Fixes #139