### PR TITLE
feat: fetch release info and asset URLs from release.lean-lang.org instead of parsing GitHub HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Fetch releases and assets from release.lean-lang.org instead of parsing GitHub HTML. Makes
+  toolchain URL resolution robust against future GitHub changes and enables use of the `beta`
+  channel to refer to the latest RC release. Also allows for distinguishing between non-existing
+  releases and non-existing assets for a release.
+
 # 4.0.1 - 2025-04-18
 
 - Fix selection of most recent stable toolchain when offline

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "dirs",
  "download",
  "error-chain",
+ "json",
  "libc",
  "openssl",
  "rand",

--- a/src/elan-cli/help.rs
+++ b/src/elan-cli/help.rs
@@ -24,14 +24,14 @@ pub static TOOLCHAIN_HELP: &str = r"DISCUSSION:
     Many `elan` commands deal with *toolchains*, a single
     installation of the Lean theorem prover. `elan` supports multiple
     types of toolchains. The most basic track the official release
-    channels: 'stable' and 'nightly'; but `elan` can also
+    channels: 'stable', 'beta', and 'nightly'; but `elan` can also
     install toolchains from the official archives and from local builds.
 
     Standard release channel toolchain names have the following form:
 
         [<origin>:]<channel>[-<date>]
 
-        <channel>       = stable|nightly|<version>
+        <channel>       = stable|beta|nightly|<version>
         <date>          = YYYY-MM-DD
 
     'channel' is either a named release channel or an explicit version
@@ -225,6 +225,6 @@ pub static COMPLETIONS_HELP: &str = r"DISCUSSION:
 
         PS C:\> elan completions powershell >> %USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1";
 
-pub static TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \
-     or '3.3.0'. For more information see `elan \
+pub static TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'beta', 'nightly', \
+     or '4.3.0'. For more information see `elan \
      help toolchain`";

--- a/src/elan-cli/self_update.rs
+++ b/src/elan-cli/self_update.rs
@@ -487,7 +487,7 @@ fn customize_install(mut opts: InstallOpts) -> Result<InstallOpts> {
     println!();
 
     opts.default_toolchain = common::question_str(
-        "Default toolchain? (stable/nightly/<specific version>/none)",
+        "Default toolchain? (stable/beta/nightly/<specific version>/none)",
         &opts.default_toolchain,
     )?;
 

--- a/src/elan-dist/src/dist.rs
+++ b/src/elan-dist/src/dist.rs
@@ -88,12 +88,8 @@ pub fn install_from_dist<'a>(
     else {
         return Ok(());
     };
-    let url = format!(
-        "https://github.com/{}/releases/expanded_assets/{}",
-        origin, release
-    );
     let res =
-        match manifestation.install(&origin, &url, &download.temp_cfg, download.notify_handler) {
+        match manifestation.install(&origin, &release, &download.temp_cfg, download.notify_handler) {
             Ok(()) => Ok(()),
             e
             @ Err(Error(ErrorKind::Utils(elan_utils::ErrorKind::DownloadNotExists { .. }), _)) => e

--- a/src/elan-dist/src/lib.rs
+++ b/src/elan-dist/src/lib.rs
@@ -12,6 +12,6 @@ pub mod dist;
 pub mod download;
 pub mod errors;
 pub mod manifest;
-mod manifestation;
+pub mod manifestation;
 pub mod notifications;
 pub mod prefix;

--- a/src/elan-utils/Cargo.toml
+++ b/src/elan-utils/Cargo.toml
@@ -23,8 +23,9 @@ curl = "0.4.34"
 openssl = { version = "0.10", features = ["vendored"] }
 regex = "1.4.3"
 dirs = "3.0.1"
+json = "0.12.4"
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3.9", features = ["combaseapi", "errhandlingapi", "fileapi", "handleapi", 
+winapi = { version = "0.3.9", features = ["combaseapi", "errhandlingapi", "fileapi", "handleapi",
     "ioapiset", "minwindef", "processthreadsapi", "shlobj", "shtypes", "userenv", "winbase", "winerror", "winnt", "winioctl"] }
 winreg = "0.8.0"

--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -6,6 +6,8 @@ use crate::notifications::*;
 use elan_dist::dist::ToolchainDesc;
 use elan_dist::download::DownloadCfg;
 use elan_dist::manifest::Component;
+use elan_dist::manifestation::DEFAULT_ORIGIN;
+use elan_dist::manifestation::DEFAULT_ORIGIN_JSON_URL;
 use elan_utils::utils;
 use elan_utils::utils::fetch_url;
 use itertools::Itertools;
@@ -18,8 +20,6 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-const DEFAULT_ORIGIN: &str = "leanprover/lean4";
 
 /// A fully resolved reference to a toolchain which may or may not exist
 pub struct Toolchain<'a> {
@@ -136,7 +136,17 @@ pub fn resolve_toolchain_desc_ext(
                 use_cache,
             )
         } else if release == "stable" || release == "beta" || release == "nightly" {
-            match utils::fetch_latest_release_tag(origin, no_net) {
+            let fetch = if origin.starts_with(DEFAULT_ORIGIN) {
+                utils::fetch_latest_release_json(DEFAULT_ORIGIN_JSON_URL, release, no_net)
+            } else {
+                if release == "beta" {
+                    return Err(Error::from(
+                        format!("channel 'beta' is not supported for custom origin '{}'", origin)
+                    ));
+                }
+                utils::fetch_latest_release_tag(origin, no_net)
+            };
+            match fetch {
                 Ok(release) => Ok(ToolchainDesc::Remote {
                     origin: origin.clone(),
                     release,


### PR DESCRIPTION
Makes toolchain URL resolution robust against future GitHub changes and enables use of the `beta` channel to refer to the latest RC release. Also allows for distinguishing between non-existing releases and non-existing assets for a release.