### PR TITLE
feat: show target of links in in "elan show"

### DIFF
--- a/src/elan-utils/src/errors.rs
+++ b/src/elan-utils/src/errors.rs
@@ -126,6 +126,12 @@ error_chain! {
             description("could not symlink directory")
             display("could not create link from '{}' to '{}'", src.display(), dest.display())
         }
+        ReadingSymlink {
+            path: PathBuf,
+        } {
+            description("could not read symlink")
+            display("could not read symlink at '{}'", path.display())
+        }
         CopyingDirectory {
             src: PathBuf,
             dest: PathBuf,

--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -140,9 +140,10 @@ pub fn resolve_toolchain_desc_ext(
                 utils::fetch_latest_release_json(uri, release, no_net)
             } else {
                 if release == "beta" {
-                    return Err(Error::from(
-                        format!("channel 'beta' is not supported for custom origin '{}'", origin)
-                    ));
+                    return Err(Error::from(format!(
+                        "channel 'beta' is not supported for custom origin '{}'",
+                        origin
+                    )));
                 }
                 utils::fetch_latest_release_tag(origin, no_net)
             };
@@ -232,6 +233,9 @@ impl<'a> Toolchain<'a> {
         fs::symlink_metadata(&self.path)
             .map(|m| m.file_type().is_symlink())
             .unwrap_or(false)
+    }
+    pub fn symlink_target(&self) -> Result<Option<PathBuf>> {
+        Ok(utils::read_link(&self.path)?)
     }
     pub fn exists(&self) -> bool {
         // HACK: linked toolchains are symlinks, and, contrary to what std docs


### PR DESCRIPTION
When doing `elan show` after

```
elan toolchain link lean4-pgit /home/user/build/release/stage1
```

the output now shows

```
installed toolchains
--------------------

lean4 (linked to local path /home/user/build/release/stage1)
leanprover/lean4:v4.22.0
leanprover/lean4:v4.23.0 (resolved from default 'stable')
leanprover/lean4:v4.24.0-rc1

active toolchain
----------------

leanprover/lean4:v4.23.0 (resolved from default 'stable')
Lean (version 4.23.0, x86_64-unknown-linux-gnu, commit 50aaf682e9b74ab92880292a25c68baa1cc81c87, Release)
```

with the novelty being the `(linked to local path /home/user/build/release/stage1)` message.