### PR TITLE
Remove ole32-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -81,7 +81,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -391,7 +391,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ dependencies = [
  "toml",
  "url",
  "wait-timeout",
- "winapi 0.3.9",
+ "winapi",
  "winreg 0.8.0",
  "zip",
 ]
@@ -485,7 +485,6 @@ dependencies = [
  "itertools",
  "json",
  "libc",
- "ole32-sys",
  "regex",
  "remove_dir_all",
  "serde",
@@ -494,7 +493,7 @@ dependencies = [
  "time",
  "toml",
  "url",
- "winapi 0.3.9",
+ "winapi",
  "winreg 0.8.0",
  "zip",
  "zstd 0.12.4",
@@ -518,7 +517,7 @@ dependencies = [
  "semver 0.11.0",
  "toml",
  "url",
- "winapi 0.3.9",
+ "winapi",
  "winreg 0.8.0",
 ]
 
@@ -646,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1276,16 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ole32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +1864,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2200,12 +2189,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2213,12 +2196,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2395,7 +2372,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d107f8c6e916235c4c01cabb3e8acf7bea8ef6a63ca2e7fa0527c049badfc48c"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]

--- a/src/elan-dist/Cargo.toml
+++ b/src/elan-dist/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 regex = "1.4.3"
 itertools = "0.10.0"
-ole32-sys = "0.2.0"
 url = "2.2.1"
 tar = "0.4.33"
 flate2 = "1.0.14"


### PR DESCRIPTION
Removes the ole32-sys crate dependency. As far as I can see, this isn't referenced anywhere in the code.

The crate hasn't been updated upstream for almost 10 years https://crates.io/crates/ole32-sys/0.2.0

It was removed from rustup some time ago: https://github.com/rust-lang/rustup/pull/1759

Result of running:
```
cargo remove --manifest-path=src/elan-dist/Cargo.toml ole32-sys
```

Previously #178