### PR TITLE
Upgrade pulldown-cmark from 0.11 to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags 2.6.0",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = "2.33.3"
 error-chain = "0.12.4"
 itertools = "0.10.0"
 libc = "0.2.82"
-pulldown-cmark = { version = "0.12", default-features = false }
+pulldown-cmark = { version = "0.13", default-features = false }
 rand = "0.8.2"
 regex = "1.4.3"
 remove_dir_all = "0.8.0"

--- a/src/elan-cli/term2.rs
+++ b/src/elan-cli/term2.rs
@@ -201,6 +201,8 @@ impl<'a, T: Instantiable + Isatty + io::Write + 'a> LineFormatter<'a, T> {
             Tag::Link { .. } => {}
             Tag::Image { .. } => {}
             Tag::FootnoteDefinition(_name) => {}
+            Tag::Superscript => {}
+            Tag::Subscript => {}
         }
     }
 
@@ -244,6 +246,8 @@ impl<'a, T: Instantiable + Isatty + io::Write + 'a> LineFormatter<'a, T> {
             TagEnd::Image { .. } => {} // shouldn't happen, handled in start
             TagEnd::FootnoteDefinition => {}
             TagEnd::MetadataBlock(_) => {}
+            TagEnd::Superscript => {}
+            TagEnd::Subscript => {}
         }
     }
 


### PR DESCRIPTION
Upgrade pulldown-cmark from 0.11 to 0.13, guided by the equivalent rustup PRs:

- https://github.com/rust-lang/rustup/pull/3999
- https://github.com/rust-lang/rustup/pull/4188