### PR TITLE
feat: add homebrew installation method to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The toolchains downloaded by elan require some patching on NixOS, which is done 
 ```bash
 $ nix-env -iA nixpkgs.elan
 ```
+## Homebrew
+```bash
+brew install elan-init
+```
 
 # Prerequisites
 


### PR DESCRIPTION
When I first read the `README.md` a while ago, I saw there was no Homebrew installation method mentioned.
A `brew search elan` retuned a lot of results, one of which being a `elan-init` formulae.
Though to add this installation method to the README.