### PR TITLE
fix: error on bad path-based toolchain instead of silent default download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix detection of being inside a toolchain directory on Windows when the path is reported with a lowercase drive letter (#199).
 - Replace leftover Rust term "crate" with "package" in `elan toolchain help link` (#175).
+- Error instead of silently downloading the default toolchain when `lean-toolchain` is unparseable or points to a path without `bin/lean` (#197).
 
 # 4.2.1 - 2026-03-18
 

--- a/src/elan/config.rs
+++ b/src/elan/config.rs
@@ -193,9 +193,10 @@ impl Cfg {
                 return Ok(Some((UnresolvedToolchainDesc(name), reason)));
             }
 
-            // Then look for 'lean-toolchain'
+            // Then look for 'lean-toolchain' (we should not be silent about invalid files here)
             let toolchain_file = d.join("lean-toolchain");
-            if let Ok(desc) = read_unresolved_toolchain_desc_from_file(self, &toolchain_file) {
+            if toolchain_file.is_file() {
+                let desc = read_unresolved_toolchain_desc_from_file(self, &toolchain_file)?;
                 let reason = OverrideReason::ToolchainFile(toolchain_file);
                 gc::add_root(self, d)?;
                 return Ok(Some((desc, reason)));
@@ -203,7 +204,8 @@ impl Cfg {
 
             // Then look for 'leanpkg.toml'
             let leanpkg_file = d.join("leanpkg.toml");
-            if let Ok(content) = utils::read_file("leanpkg.toml", &leanpkg_file) {
+            if leanpkg_file.is_file() {
+                let content = utils::read_file("leanpkg.toml", &leanpkg_file)?;
                 let value = content
                     .parse::<toml::Value>()
                     .map_err(|error| ErrorKind::InvalidLeanpkgFile(leanpkg_file.clone(), error))?;

--- a/src/elan/toolchain.rs
+++ b/src/elan/toolchain.rs
@@ -218,11 +218,29 @@ fn try_parse_path_toolchain(
 
     // Validate that bin/lean exists
     let lean_binary = path.join("bin").join(format!("lean{}", EXE_SUFFIX));
-    if !lean_binary.is_file() {
-        return Ok(None); // Not a valid Lean toolchain directory
+    if lean_binary.is_file() {
+        return Ok(Some(ToolchainDesc::Path { path }));
     }
 
-    Ok(Some(ToolchainDesc::Path { path }))
+    // Error on path-like input rather than falling through to toolchain-name parsing, which would
+    // silently attempt to download a default toolchain.
+    if looks_like_explicit_path(path_str) {
+        return Err(Error::from(format!(
+            "no Lean toolchain found at '{}': expected '{}' to exist",
+            path.display(),
+            lean_binary.display()
+        )));
+    }
+
+    Ok(None)
+}
+
+fn looks_like_explicit_path(s: &str) -> bool {
+    Path::new(s).is_absolute()
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.starts_with(".\\")
+        || s.starts_with("..\\")
 }
 
 #[cfg(test)]
@@ -288,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn path_without_lean_binary_returns_none() {
+    fn absolute_path_without_lean_binary_errors() {
         let tc_dir = TempDir::new().unwrap();
         fs::create_dir(tc_dir.path().join("bin")).unwrap();
         // bin/lean is intentionally absent
@@ -296,19 +314,32 @@ mod tests {
         let result = try_parse_path_toolchain(
             tc_dir.path().to_str().unwrap(),
             Path::new("/irrelevant"),
-        )
-        .unwrap();
+        );
 
-        assert!(result.is_none());
+        assert!(result.is_err(), "explicit path with no bin/lean should error");
     }
 
     #[test]
-    fn nonexistent_path_returns_none() {
-        let result =
-            try_parse_path_toolchain("/nonexistent/path/that/does/not/exist", Path::new("/"))
-                .unwrap();
+    fn nonexistent_absolute_path_errors() {
+        // TempDir gives us a platform-absolute path; the joined subpath doesn't exist.
+        let base = TempDir::new().unwrap();
+        let nonexistent = base.path().join("does-not-exist");
+        let result = try_parse_path_toolchain(nonexistent.to_str().unwrap(), Path::new("/"));
 
-        assert!(result.is_none());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn nonexistent_relative_path_with_dot_prefix_errors() {
+        // Regression test for #197: `../foo` in lean-toolchain should error
+        // when the path doesn't contain bin/lean, not silently fall back to a
+        // default toolchain download.
+        let base = TempDir::new().unwrap();
+        let result = try_parse_path_toolchain("../nope/build/stage1", base.path());
+        assert!(result.is_err(), "{result:?}");
+
+        let result = try_parse_path_toolchain("./nope", base.path());
+        assert!(result.is_err(), "{result:?}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #197. When `lean-toolchain` contains a path-like value (e.g. `../foo`, `/abs/foo`) that does not point to a directory with `bin/lean`, elan now errors with a clear message instead of silently falling back to downloading the default toolchain. Bare names without path syntax still fall through to toolchain-name resolution, preserving the bare-name-as-path support from #195.

Additionally, parse errors from a present `lean-toolchain` or `leanpkg.toml` are now propagated instead of being swallowed by `if let Ok(...)`, so e.g. empty files and unparseable names produce a real error.