### PR TITLE
fix: replace leftover Rust term "crate" with "package" in `elan toolchain help link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix detection of being inside a toolchain directory on Windows when the path is reported with a lowercase drive letter (#199).
+- Replace leftover Rust term "crate" with "package" in `elan toolchain help link` (#175).
 
 # 4.2.1 - 2026-03-18
 

--- a/src/elan-cli/help.rs
+++ b/src/elan-cli/help.rs
@@ -58,7 +58,7 @@ pub static TOOLCHAIN_LINK_HELP: &str = r"DISCUSSION:
         $ elan toolchain link master <path/to/lean/root>
         $ elan override set master
 
-    If you now compile a crate in the current directory, the custom
+    If you now compile a package in the current directory, the custom
     toolchain 'master' will be used.";
 
 pub static TOOLCHAIN_GC_HELP: &str = r"DISCUSSION:


### PR DESCRIPTION
Fixes #175