### PR TITLE
Minor refactor of elan-init.ps1 for ContrainedLanguage Mode

### DIFF
--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -37,8 +37,15 @@ param(
 # There are no Windows ARM releases yet, use emulated x64
 $_arch = "x86_64-pc-windows-msvc"
 $_ext = ".exe"
-$temp = [System.IO.Path]::GetTempPath()
+
+# CLM-safe temp path: [System.IO.Path]::GetTempPath() is a static method call
+# on a non-allow-listed type and is blocked in ConstrainedLanguage. Use the
+# environment variable instead (reading $env: is permitted in CLM).
+$temp = $env:TEMP
+if (-not $temp) { $temp = $env:TMP }
+
 $_dir = Join-Path $temp "elan"
+
 if (-not (Test-Path -Path $_dir)) {
     $null = New-Item -ItemType Directory -Path $_dir
 }

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -38,12 +38,20 @@ param(
 $_arch = "x86_64-pc-windows-msvc"
 $_ext = ".exe"
 
-# CLM-safe temp path: [System.IO.Path]::GetTempPath() is a static method call
-# on a non-allow-listed type and is blocked in ConstrainedLanguage. Use the
-# environment variable instead (reading $env: is permitted in CLM).
-$temp = $env:TMP
-if (-not $temp) { $temp = $env:TEMP }
-if (-not $temp) { $temp = $env:USERPROFILE }
+if ($ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage') {
+    $temp = [System.IO.Path]::GetTempPath()
+}
+else
+{
+    # CLM-safe temp path: [System.IO.Path]::GetTempPath() is a static method call on a non-allow-listed type and is blocked in ConstrainedLanguage. 
+    # Use the environment variable instead (reading $env: is permitted in CLM) to mirror the lookup behaviour of [System.IO.Path]::GetTempPath()
+    $temp = $env:TMP
+    if (-not $temp) { $temp = $env:TEMP }
+    if (-not $temp) { $temp = $env:USERPROFILE }
+    if (-not $temp) { $temp = $env:SystemRoot }
+    if (-not $temp) { throw "Unable to resolve a temporary directory. All candidate sources (TMP/TEMP/USERPROFILE/SystemRoot) were not found." }
+}
+
 $_dir = Join-Path $temp "elan"
 
 if (-not (Test-Path -Path $_dir)) {

--- a/elan-init.ps1
+++ b/elan-init.ps1
@@ -41,9 +41,9 @@ $_ext = ".exe"
 # CLM-safe temp path: [System.IO.Path]::GetTempPath() is a static method call
 # on a non-allow-listed type and is blocked in ConstrainedLanguage. Use the
 # environment variable instead (reading $env: is permitted in CLM).
-$temp = $env:TEMP
-if (-not $temp) { $temp = $env:TMP }
-
+$temp = $env:TMP
+if (-not $temp) { $temp = $env:TEMP }
+if (-not $temp) { $temp = $env:USERPROFILE }
 $_dir = Join-Path $temp "elan"
 
 if (-not (Test-Path -Path $_dir)) {


### PR DESCRIPTION
The current version of `elan-init.ps1` does not work in ConstrainedLanguage Mode of powershell for only one line
```
$temp = [System.IO.Path]::GetTempPath()
```

Replace that line with $env equivalents to work in ConstrainedLanguage Mode
```
$temp = $env:TMP
if (-not $temp) { $temp = $env:TEMP }
if (-not $temp) { $temp = $env:USERPROFILE }
```
